### PR TITLE
feat(fastify): introduced $BLOCKFROST_CONFIG_SERVER_LISTEN_ADDRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ There are several configuration files in `config` directory. Config file is pick
 {
   // Blockfrost backend settings
   server: {
+    // Server listen address, you need to set this to 0.0.0.0 if running within docker
+    listenAddress: 'localhost',
     // Server port
     port: 3000,
     // Whether to enable verbose logging, when disabled only ERRORs are printed to a console
@@ -80,7 +82,8 @@ We are hosting latest release of this software on Dockerhub. To run it using Doc
 docker run --rm \
   --name blockfrost-ryo \
   -p 3000:3000 \
-  -v ./config:/app/config \
+  -e BLOCKFROST_CONFIG_SERVER_LISTEN_ADDRESS=0.0.0.0 \
+  -v $PWD/config:/app/config \
   blockfrost/backend-ryo:latest
  ```
 

--- a/config/development-testnet.ts
+++ b/config/development-testnet.ts
@@ -1,5 +1,6 @@
 export default {
   server: {
+    listenAddress: 'localhost',
     port: 3000,
     debug: true,
   },

--- a/config/development.ts
+++ b/config/development.ts
@@ -1,5 +1,6 @@
 export default {
   server: {
+    listenAddress: 'localhost',
     port: 3000,
     debug: true,
   },

--- a/config/mainnet.ts
+++ b/config/mainnet.ts
@@ -1,5 +1,6 @@
 export default {
   server: {
+    listenAddress: 'localhost',
     port: 3000,
     debug: true,
   },

--- a/config/test.ts
+++ b/config/test.ts
@@ -1,5 +1,6 @@
 export default {
   server: {
+    listenAddress: 'localhost',
     port: 3000,
     debug: true,
   },

--- a/config/testnet.ts
+++ b/config/testnet.ts
@@ -1,5 +1,6 @@
 export default {
   server: {
+    listenAddress: 'localhost',
     port: 3000,
     debug: true,
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ import { CARDANO_NETWORKS, Network } from './types/common';
 
 export const loadConfig = () => {
   // server
+  const listenAddress = process.env.BLOCKFROST_CONFIG_SERVER_LISTEN_ADDRESS
+    ?? config.get<string>('server.listenAddress');
   const port = process.env.BLOCKFROST_CONFIG_SERVER_PORT
     ? Number(process.env.BLOCKFROST_CONFIG_SERVER_PORT)
     : config.get<number>('server.port');
@@ -36,6 +38,7 @@ export const loadConfig = () => {
 
   return {
     server: {
+      listenAddress,
       port,
       debug,
       prometheusMetrics,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import app from './app';
 import { getConfig } from './config';
 
 const port = getConfig().server.port;
+const address = getConfig().server.listenAddress;
 const debug = getConfig().server.debug;
 
 const server = app({
@@ -25,7 +26,7 @@ const server = app({
   maxParamLength: 32_768,
 });
 
-server.listen({ port }, error => {
+server.listen(port, address, error => {
   if (error) {
     console.error(error);
     // eslint-disable-next-line unicorn/no-process-exit


### PR DESCRIPTION
In order to run within docker, we need to allow fastify to listen in any given address (`0.0.0.0`). This PR adds an environment variable for that and some basic doco around it.