### PR TITLE
docs(README): add some basic details on how the postgres auth works

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The system requirements for the basic Blockfrost backend stack (which means `blo
 
 There are several configuration files in `config` directory. Config file is picked based on a value in an environment variable `NODE_ENV` (value set in `NODE_ENV` must match the name of the config file). This environment variable is set automatically while running the backend via prepared `yarn` scripts.
 
+If you are using an authenticated db connection that requires a password, you'd need to provide a `PGPASSWORD` environment variable and the postgres library will automatically pick it up.
+
 #### Schema
 
 ```ts


### PR DESCRIPTION
I've found we are lacking a `BLOCKFROST_CONFIG_DBSYNC_PASSWORD` environment variable, which basically means we are relying on the postgres client library to use `PGPASSWORD` to provide a password.

I guess this was on purpose to prevent people committing passwords to config files, so I've just added a oneliner as heads up just in case people wonder how they'd se this up.