### PR TITLE
fix(network/eras): latest epoch boundary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `/addresses/{address}/utxos/{asset}` asset validation for `/lovelace`
 - 400 handling of invalid POST routes
+- `/network/eras` endpoint returning incorrect latest epoch boundary
 
 ## [1.1.1] - 2022-12-07
 

--- a/src/types/queries/scripts.ts
+++ b/src/types/queries/scripts.ts
@@ -56,6 +56,7 @@ export interface ScriptHashRedeemers {
 }
 
 export interface DatumHash {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   json_value: any;
 }
 
@@ -64,6 +65,7 @@ export interface DatumHashCbor {
 }
 
 export interface ScriptHashJson {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   json: any;
 }
 export interface ScriptHashCbor {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const registerRoute = (app: FastifyInstance, routeHandler: any) => {
   app.register(routeHandler, {
     dirNameRoutePrefix: false,

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -68,6 +68,7 @@ export const getAdditionalParametersFromRequest = (
   return parameterArray;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sortKeysInObject = (object: any) => {
   if (object === null || typeof object !== 'object') return object;
 

--- a/test/integration/fixtures/mainnet/addresses.ts
+++ b/test/integration/fixtures/mainnet/addresses.ts
@@ -178,7 +178,7 @@ export const success = [
       amount: [
         {
           unit: 'lovelace',
-          quantity: '58470546',
+          quantity: '687759947',
           decimals: 6,
           has_nft_onchain_metadata: false,
         },
@@ -293,21 +293,27 @@ export const success = [
     },
   },
   {
-    testName: 'addresses/:address BF address - used but now empty',
+    testName: 'addresses/:address BF address with summit token',
     endpoints: [
       'addresses/addr1q8zsjx7vxkl4esfejafhxthyew8c54c9ch95gkv3nz37sxrc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgq3jd3w2',
     ],
     response: {
       address:
         'addr1q8zsjx7vxkl4esfejafhxthyew8c54c9ch95gkv3nz37sxrc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgq3jd3w2',
-      amount: [{ unit: 'lovelace', quantity: '0' }],
+      amount: [
+        { unit: 'lovelace', quantity: '3932327' },
+        {
+          unit: 'd436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
+          quantity: '1',
+        },
+      ],
       stake_address: 'stake1u9uz4j024qfud557ucrqw3kqfdndjgaxj7m44x7tamkvmyqzdwe7v',
       type: 'shelley',
       script: false,
     },
   },
   {
-    testName: 'addresses/:address BF address with summit token',
+    testName: 'addresses/:address BF address - used but now empty',
     endpoints: [
       'addresses/addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz',
     ],
@@ -315,11 +321,7 @@ export const success = [
       address:
         'addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz',
       amount: [
-        { unit: 'lovelace', quantity: '3129237' },
-        {
-          unit: 'd436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
-          quantity: '1',
-        },
+        { unit: 'lovelace', quantity: '0' },
       ],
       stake_address: 'stake1u9uz4j024qfud557ucrqw3kqfdndjgaxj7m44x7tamkvmyqzdwe7v',
       type: 'shelley',
@@ -388,70 +390,65 @@ export const success = [
     response: [],
   },
   {
-    testName: 'addresses/:address/utxos BF address with summit token',
+    testName: 'addresses/:address/utxos BF address - used but now empty',
     endpoints: [
       'addresses/addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz/utxos',
     ],
-    response: [
-      {
-        address:
-          'addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz',
-        tx_hash: '99e4b01005ab6e1f440e2d3600b631df997d349e66789eaf876feb6bf03212c9',
-        tx_index: 1,
-        output_index: 1,
-        amount: [
-          { unit: 'lovelace', quantity: '3129237' },
-          {
-            unit: 'd436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
-            quantity: '1',
-          },
-        ],
-        block: 'b5363f6efc026d09d89195df27603a8d9311cad0c6569ce66fb10f73effcefee',
-        data_hash: null,
-        inline_datum: null,
-        reference_script_hash: null,
-      },
-    ],
+    response: [],
   },
   {
-    testName: 'addresses/:address/utxos BF address with summit token',
+    testName: 'addresses/:address/utxos/:asset BF address - used but now empty',
     endpoints: [
       'addresses/addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz/utxos/d436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
     ],
-    response: [
-      {
-        address:
-          'addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz',
-        tx_hash: '99e4b01005ab6e1f440e2d3600b631df997d349e66789eaf876feb6bf03212c9',
-        tx_index: 1,
-        output_index: 1,
-        amount: [
-          { unit: 'lovelace', quantity: '3129237' },
-          {
-            unit: 'd436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
-            quantity: '1',
-          },
-        ],
-        block: 'b5363f6efc026d09d89195df27603a8d9311cad0c6569ce66fb10f73effcefee',
-        data_hash: null,
-        inline_datum: null,
-        reference_script_hash: null,
-      },
-    ],
+    response: []
   },
   {
-    testName: 'addresses/:address/utxos BF address with summit token',
+    testName: 'addresses/:address/utxos BF address - used but now empty',
     endpoints: [
       'addresses/addr1q9x625ny9y42s5z8n78afjg9meyeknvt5kwm3y6sdlrz66tc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgqsyx3uz/utxos/lovelace',
     ],
     response: [],
   },
   {
-    testName: 'addresses/:address/utxos BF address - used but now empty',
+    testName: 'addresses/:address/utxos BF address with summit token',
     endpoints: [
       'addresses/addr1q8zsjx7vxkl4esfejafhxthyew8c54c9ch95gkv3nz37sxrc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgq3jd3w2/utxos',
     ],
-    response: [],
+    response: [
+      {
+        address:
+          'addr1q8zsjx7vxkl4esfejafhxthyew8c54c9ch95gkv3nz37sxrc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgq3jd3w2',
+        tx_hash: 'c34c232d6574d35a92f3bdcc6159b6d0b04f98de9f311db629f8973ac66dec10',
+        tx_index: 0,
+        output_index: 0,
+        amount: [
+          { unit: 'lovelace', quantity: '2725527' },
+        ],
+        block: 'c4c8e6a4142108ab67126281240388da8729b353177d5399195e55fdc5e3dd81',
+        data_hash: null,
+        inline_datum: null,
+        reference_script_hash: null,
+      },
+      {
+        address:
+          'addr1q8zsjx7vxkl4esfejafhxthyew8c54c9ch95gkv3nz37sxrc9ty742qncmffaesxqarvqjmxmy36d9aht2duhmhvekgq3jd3w2',
+        tx_hash: 'c34c232d6574d35a92f3bdcc6159b6d0b04f98de9f311db629f8973ac66dec10',
+        tx_index: 1,
+        output_index: 1,
+        amount: [
+          { unit: 'lovelace', quantity: '1206800' },
+          {
+            unit: 'd436d9f6b754582f798fe33f4bed12133d47493f78b944b9cc55fd1853756d6d69744c6f64676534393539',
+            quantity: '1',
+          },
+        ],
+        block: 'c4c8e6a4142108ab67126281240388da8729b353177d5399195e55fdc5e3dd81',
+        data_hash: null,
+        inline_datum: null,
+        reference_script_hash: null,
+      },
+    ],
   },
 ];
 

--- a/test/integration/tests/mainnet/network.integration.ts
+++ b/test/integration/tests/mainnet/network.integration.ts
@@ -1,0 +1,120 @@
+import { getInstance } from '../../utils';
+import { describe, test, expect } from 'vitest';
+
+const response_eras_mainnet =
+[
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 89856000,
+      slot: 4492800,
+      epoch: 208
+    },
+    parameters: {
+      epoch_length: 21600,
+      slot_length: 20,
+      safe_zone: 4320
+    }
+  },
+  {
+    start: {
+      time: 89856000,
+      slot: 4492800,
+      epoch: 208
+    },
+    end: {
+      time: 101952000,
+      slot: 16588800,
+      epoch: 236
+    },
+    parameters: {
+      epoch_length: 432000,
+      slot_length: 1,
+      safe_zone: 129600
+    }
+  },
+  {
+    start: {
+      time: 101952000,
+      slot: 16588800,
+      epoch: 236
+    },
+    end: {
+      time: 108432000,
+      slot: 23068800,
+      epoch: 251
+    },
+    parameters: {
+      epoch_length: 432000,
+      slot_length: 1,
+      safe_zone: 129600
+    }
+  },
+  {
+    start: {
+      time: 108432000,
+      slot: 23068800,
+      epoch: 251
+    },
+    end: {
+      time: 125280000,
+      slot: 39916800,
+      epoch: 290
+    },
+    parameters: {
+      epoch_length: 432000,
+      slot_length: 1,
+      safe_zone: 129600
+    }
+  },
+  {
+    start: {
+      time: 125280000,
+      slot: 39916800,
+      epoch: 290
+    },
+    end: {
+      time: 157680000,
+      slot: 72316800,
+      epoch: 365
+    },
+    parameters: {
+      epoch_length: 432000,
+      slot_length: 1,
+      safe_zone: 129600
+    }
+  },
+  {
+    start: {
+      time: 157680000,
+      slot: 72316800,
+      epoch: 365
+    },
+    end: {
+      time: expect.any(Number),
+      slot: expect.any(Number),
+      epoch: expect.any(Number)
+    },
+    parameters: {
+      epoch_length: 432000,
+      slot_length: 1,
+      safe_zone: 129600
+    }
+  }
+];
+
+describe('network endpoint', () => {
+  test('/network/eras', async () => {
+    const client = getInstance();
+    const response = await client
+      .get('network/eras').json();
+
+    expect(response).toStrictEqual(
+      expect.arrayContaining(response_eras_mainnet),
+    );
+  });
+});

--- a/test/unit/fixtures/network.fixtures.ts
+++ b/test/unit/fixtures/network.fixtures.ts
@@ -24,7 +24,7 @@ const response_network = {
   stake: { live: '23204521899908362', active: '23210733595257321' },
 };
 
-const query_last_epoch_mainnet = [{ epoch: 376 }];
+const query_last_epoch_mainnet = [{ epoch: 376, epoch_slot: 1 }];
 const query_param_proposal_mainnet = [
   { epoch: 235, protocol_major: 3 },
   { epoch: 250, protocol_major: 4 },
@@ -127,9 +127,9 @@ const response_eras_mainnet =
       epoch: 365
     },
     end: {
-      time: 163296000,
-      slot: 77932800,
-      epoch: 378
+      time: 162864000,
+      slot: 77500800,
+      epoch: 377
     },
     parameters: {
       epoch_length: 432000,
@@ -139,7 +139,7 @@ const response_eras_mainnet =
   }
 ];
 
-const query_last_epoch_testnet = [{ epoch: 242 }];
+const query_last_epoch_testnet = [{ epoch: 242, epoch_slot: 1 }];
 const query_param_proposal_testnet = [
   { epoch: 101, protocol_major: 3 },
   { epoch: 111, protocol_major: 4 },
@@ -241,9 +241,9 @@ const response_eras_testnet = [
       epoch: 215
     },
     end: {
-      time: 105408000,
-      slot: 75038400,
-      epoch: 244
+      time: 104976000,
+      slot: 74606400,
+      epoch: 243
     },
     parameters: {
       epoch_length: 432000,
@@ -253,7 +253,7 @@ const response_eras_testnet = [
   }
 ];
 
-const query_last_epoch_preprod = [{ epoch: 33 }];
+const query_last_epoch_preprod = [{ epoch: 33, epoch_slot: 1 }];
 const query_param_proposal_preprod = [
   { epoch: 4, protocol_major: 3 },
   { epoch: 5, protocol_major: 4 },
@@ -355,9 +355,9 @@ const response_eras_preprod = [
       epoch: 12
     },
     end: {
-      time: 15120000,
-      slot: 13478400,
-      epoch: 35
+      time: 14688000,
+      slot: 13046400,
+      epoch: 34
     },
     parameters: {
       epoch_length: 432000,
@@ -367,7 +367,7 @@ const response_eras_preprod = [
   }
 ];
 
-const query_last_epoch_preview = [{ epoch: 25 }];
+const query_last_epoch_preview = [{ epoch: 25, epoch_slot: 1 }];
 const query_param_proposal_preview = [
   { epoch: 2, protocol_major: 7 },
   { epoch: 21, protocol_major: 8 },
@@ -466,9 +466,9 @@ const response_eras_preview = [
       epoch: 3
     },
     end: {
-      time: 2332800,
-      slot: 2332800,
-      epoch: 27
+      time: 2246400,
+      slot: 2246400,
+      epoch: 26
     },
     parameters: {
       epoch_length: 86400,
@@ -477,6 +477,115 @@ const response_eras_preview = [
     }
   }
 ];
+
+// within safe zone
+const query_last_epoch_preview_safe = [{ epoch: 70, epoch_slot: 65536 }];
+
+const response_eras_preview_safe = [
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    parameters: {
+      epoch_length: 4320,
+      slot_length: 20,
+      safe_zone: 864
+    }
+  },
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    parameters: {
+      epoch_length: 86400,
+      slot_length: 1,
+      safe_zone: 25920
+    }
+  },
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    parameters: {
+      epoch_length: 86400,
+      slot_length: 1,
+      safe_zone: 25920
+    }
+  },
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    parameters: {
+      epoch_length: 86400,
+      slot_length: 1,
+      safe_zone: 25920
+    }
+  },
+  {
+    start: {
+      time: 0,
+      slot: 0,
+      epoch: 0
+    },
+    end: {
+      time: 259200,
+      slot: 259200,
+      epoch: 3
+    },
+    parameters: {
+      epoch_length: 86400,
+      slot_length: 1,
+      safe_zone: 25920
+    }
+  },
+  {
+    start: {
+      time: 259200,
+      slot: 259200,
+      epoch: 3
+    },
+    end: {
+      time: 6220800,
+      slot: 6220800,
+      epoch: 72
+    },
+    parameters: {
+      epoch_length: 86400,
+      slot_length: 1,
+      safe_zone: 25920
+    }
+  }
+];
+
 
 const response_500 = {
   error: 'Internal Server Error',
@@ -551,6 +660,18 @@ export default [
     },
     network: 'preview',
     response: response_eras_preview,
+  },
+  {
+    name: 'PREVIEW: respond with success and data on /network/eras when within safe zone',
+    endpoint: '/network/eras',
+    sqlQueryMock: {
+      rows: query_last_epoch_preview_safe,
+    },
+    sqlQueryMock2: {
+      rows: query_param_proposal_preview,
+    },
+    network: 'preview',
+    response: response_eras_preview_safe,
   },
 
 


### PR DESCRIPTION
is `current epoch + 2` only when we are in the safe zone (`current slot
in epoch >= epoch length - safe zone`) where hardfork can no longer occur.

Otherwise it is `current epoch + 1`.