### PR TITLE
fix(cip68): catch errors caused by invalid datum

### DIFF
--- a/src/routes/addresses/address/extended.ts
+++ b/src/routes/addresses/address/extended.ts
@@ -81,15 +81,20 @@ async function route(fastify: FastifyInstance) {
               const datumHex = rows[0].cbor;
 
               if (datumHex) {
-                const datumMetadata = getMetadataFromOutputDatum(datumHex);
-                const result = validateCIP68Metadata(datumMetadata, referenceNFT.standard);
+                try {
+                  const datumMetadata = getMetadataFromOutputDatum(datumHex);
+                  const result = validateCIP68Metadata(datumMetadata, referenceNFT.standard);
 
-                if (result) {
-                  onchainMetadata = result.metadata;
-                  decimals =
-                    referenceNFT.standard === 'ft' && typeof result.metadata.decimals === 'number'
-                      ? result.metadata.decimals
-                      : decimals;
+                  if (result) {
+                    onchainMetadata = result.metadata;
+                    decimals =
+                      referenceNFT.standard === 'ft' && typeof result.metadata.decimals === 'number'
+                        ? result.metadata.decimals
+                        : decimals;
+                  }
+                } catch (error) {
+                  // Invalid datum hex, should not happen
+                  console.error(`Error while validating CIP68 datum ${datumHex}`, error);
                 }
               }
             }

--- a/src/routes/assets/asset/index.ts
+++ b/src/routes/assets/asset/index.ts
@@ -51,12 +51,17 @@ async function route(fastify: FastifyInstance) {
           const datumHex = rows[0].cbor;
 
           if (datumHex) {
-            const datumMetadata = getMetadataFromOutputDatum(datumHex);
-            const result = validateCIP68Metadata(datumMetadata, referenceNFT.standard);
+            try {
+              const datumMetadata = getMetadataFromOutputDatum(datumHex);
+              const result = validateCIP68Metadata(datumMetadata, referenceNFT.standard);
 
-            if (result) {
-              onchainMetadata = result.metadata;
-              onchainMetadataStandard = result.version;
+              if (result) {
+                onchainMetadata = result.metadata;
+                onchainMetadataStandard = result.version;
+              }
+            } catch (error) {
+              // Invalid datum hex, should not happen
+              console.error(`Error while validating CIP68 datum ${datumHex}`, error);
             }
           }
         }


### PR DESCRIPTION
`getMetadataFromOutputDatum` can throw an error if datum cbor is not valid (eg. malformed hex or there could be a bug in parsing lib).