### PR TITLE
feat(nix): configurable memory for pm2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - support for CIP68 onchain metadata in `/assets/{asset}` and `/addresses/{address}/extended`
+- support for configurable memory settings for pm2 in the nix service
 
 ### Changed
 

--- a/default.nix
+++ b/default.nix
@@ -59,8 +59,8 @@ rec {
         ${nodePackages.pm2}/bin/pm2 delete all; \
            ${nodePackages.pm2}/bin/pm2 start \
            $out/libexec/source/dist/server.js \
-           --interpreter=${pkgs.nodejs-16_x}/bin/node --node-args="--max-http-header-size=32768" \
-           --max-memory-restart 1500M \
+           --interpreter=${pkgs.nodejs-16_x}/bin/node --node-args="\''${BLOCKFROST_NODE_ARGS:-"--max-http-header-size=32768"}" \
+           --max-memory-restart \''${BLOCKFROST_MAX_MEMORY_RESTART:-"1500M"} \
            -i max --time --no-daemon
         EOF
         chmod +x $out/bin/${name}


### PR DESCRIPTION
This change makes the memory monitored by pm2 configurable by env variables.