### PR TITLE
nix: add missing -ryo suffix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nixos/nix
 COPY . /app
 WORKDIR /app
-RUN nix-build -A blockfrost-backend
-RUN ln -s $(nix-build -A blockfrost-backend --no-out-link)/bin/blockfrost-backend /app/blockfrost-backend
-ENTRYPOINT ["/app/blockfrost-backend"]
+RUN nix-build -A blockfrost-backend-ryo
+RUN ln -s $(nix-build -A blockfrost-backend-ryo --no-out-link)/bin/blockfrost-backend-ryo /app/blockfrost-backend-ryo
+ENTRYPOINT ["/app/blockfrost-backend-ryo"]
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker run --rm \
 To start the Blockfrost backend under nix, just run:
 
 ```console
-$(nix-build -A blockfrost-backend --no-out-link)/bin/blockfrost-backend
+$(nix-build -A blockfrost-backend-ryo --no-out-link)/bin/blockfrost-backend-ryo
 ```
 
 ## Developing


### PR DESCRIPTION
in Readme and Dockerfile