### PR TITLE
fix(txs,scripts) correct value for datum_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- incorrect `datum_hash` in `/txs` and `/scripts`
+
 ## [1.3.0] - 2023-01-15
 
 ### Added

--- a/src/sql/scripts/scripts_script_hash_redeemers.sql
+++ b/src/sql/scripts/scripts_script_hash_redeemers.sql
@@ -5,10 +5,11 @@ SELECT encode(tx.hash, 'hex') "tx_hash",
   r.unit_steps::TEXT AS "unit_steps", -- cast to TEXT to avoid number overflow
   r.fee::TEXT AS "fee", -- cast to TEXT to avoid number overflow
   encode(redeemer_data.hash, 'hex') AS "redeemer_data_hash",
-  encode(redeemer_data.hash, 'hex') AS "datum_hash" -- deprecated
+  encode(datum.hash, 'hex') AS "datum_hash" -- deprecated
 FROM redeemer r
   JOIN tx ON (r.tx_id = tx.id)
   JOIN redeemer_data ON (r.redeemer_data_id = redeemer_data.id)
+  JOIN datum ON (r.tx_id = datum.tx_id)
 WHERE encode(r.script_hash, 'hex') = $4
 ORDER BY CASE
     WHEN LOWER($1) = 'desc' THEN r.id

--- a/src/sql/txs/txs_hash_redeemers.sql
+++ b/src/sql/txs/txs_hash_redeemers.sql
@@ -5,9 +5,10 @@ SELECT r.index AS "tx_index",
   r.fee::TEXT AS "fee", -- cast to TEXT to avoid number overflow
   encode(r.script_hash, 'hex') AS "script_hash",
   encode(redeemer_data.hash, 'hex') AS "redeemer_data_hash",
-  encode(redeemer_data.hash, 'hex') AS "datum_hash" -- deprecated
+  encode(datum.hash, 'hex') AS "datum_hash" -- deprecated
 FROM redeemer r
   JOIN tx ON (r.tx_id = tx.id)
   JOIN redeemer_data ON (r.redeemer_data_id = redeemer_data.id)
+  JOIN datum ON (r.tx_id = datum.tx_id)
 WHERE encode(tx.hash, 'hex') = $1
 ORDER BY r.index ASC


### PR DESCRIPTION
A bug did show the redeemer hash instead of the datum hash.