### PR TITLE
fix(scripts): `/scripts/datum/{datum-hash}/cbor` returns redeemer CBOR too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - nixpkgs updated to latest `nixos-22.11` and hence NodeJS to `16.18.1`
 - do not leak framework in errors
 
+### Fixed
+
+- `/scripts/datum/{datum-hash}/cbor` endpoint adjusted to return `CBOR` of redeemers as well (similar to JSON variant at `/scripts/datum/{datum-hash}` endpoint)
+
 ## [1.4.0] - 2023-02-07
 
 ### Added

--- a/src/sql/scripts/scripts_datum_datum_hash_cbor.sql
+++ b/src/sql/scripts/scripts_datum_datum_hash_cbor.sql
@@ -1,3 +1,9 @@
+-- data hash refers to either datum or redeemer_data
 SELECT encode(bytes, 'hex') AS "cbor"
 FROM datum d
 WHERE encode(d.hash, 'hex') = $1
+-- UNION with redeemer_data
+UNION
+SELECT encode(bytes, 'hex') AS "cbor"
+FROM redeemer_data rd
+WHERE encode(rd.hash, 'hex') = $1


### PR DESCRIPTION
Fixed to have a similar behavior as `/scripts/datum/{datum-hash}` endpoint that looks into both tables correctly when querying `JSON` value.