### PR TITLE
chore: add `x86_64-darwin` to supportedSystems in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
   outputs = { self, nixpkgs }:
     let
       lib = nixpkgs.lib;
-      supportedSystems = [ "x86_64-linux" ];
+      supportedSystems = [ 
+        "x86_64-linux"
+        "x86_64-darwin" 
+      ];
       forAllSystems = f: lib.genAttrs supportedSystems (system: f system);
       legacyPkgs = nixpkgs.legacyPackages;
       default = lib.genAttrs supportedSystems (system: import ./default.nix {


### PR DESCRIPTION
Resolves https://github.com/blockfrost/blockfrost-backend-ryo/issues/105