### PR TITLE
NixOS module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
 , system ? builtins.currentSystem
 }:
 let
-  nodejs = pkgs.nodejs-16_x;
+  nodejs = pkgs.nodejs-18_x;
   nodePackages = nodejs.pkgs;
   testing = import (pkgs.path + "/nixos/lib/testing-python.nix") { inherit system; };
   packageJSON = builtins.fromJSON (builtins.readFile ./package.json);

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676253841,
-        "narHash": "sha256-jhuI8Mmky8VCD45OoJEuF6HdPLFBwNrHA0ljjZ/zkfw=",
+        "lastModified": 1687420147,
+        "narHash": "sha256-NILbmZVsoP2Aw0OAIXdbYXrWc/qggIDDyIwZ01yUx+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a45a8916243a7d27acc358f4fc18c4491f3eeca8",
+        "rev": "d449a456ba7d81038fc9ec9141eae7ee3aaf2982",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Blockfrost API backend";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.11"; 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
 
   outputs = { self, nixpkgs }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Blockfrost API backend";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.11"; 
 
   outputs = { self, nixpkgs }:
     let
@@ -55,8 +55,12 @@
         };
         default = self.apps.${system}.blockfrost-backend-ryo;
       });
-      overlays.default = self: super: {
-        inherit (self.packages.${super.system}) blockfrost-backend;
+      overlays.default = final: prev: {
+        inherit (self.packages.${prev.system}) blockfrost-backend-ryo;
+      };
+      nixosModules.default = {pkgs, ...}: {
+        imports = [ ./nixos-module.nix ];
+        services.blockfrost.package = self.packages.${pkgs.system}.blockfrost-backend-ryo;
       };
     };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,0 +1,129 @@
+{config, pkgs, lib, ...}: let
+  cfg = config.services.blockfrost;
+  settingsFormat = pkgs.formats.json {};
+in {
+   options = {
+    services.blockfrost  = {
+      enable = lib.mkEnableOption "Blockfrost";
+      package = lib.mkOption {
+        type = lib.types.package;
+      };
+      stateDir = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.baseWorkDir}blockfrost";
+      };
+      user = lib.mkOption {
+        description = "User to run blockfrost service as";
+        type = lib.types.str;
+        default = "blockfrost";
+      };
+      group = lib.mkOption {
+        description = "Group to run blockfrost service as";
+        type = lib.types.str;
+        default = "blockfrost";
+      };
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+          options = {
+            server = {
+              listenAddress = lib.mkOption {
+                type = lib.types.str;
+                default = "localhost";
+              };
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 3000;
+              };
+              debug = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+              };
+              prometheusMetrics = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+              };
+            };
+            dbSync = {
+              host = lib.mkOption {
+                type = lib.types.str;
+                default = "localhost";
+              };
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 3000;
+              };
+              user = lib.mkOption {
+                type = lib.types.str;
+                default = "cexplorer";
+              };
+              database = lib.mkOption {
+                type = lib.types.str;
+                default = "cdbsync";
+              };
+              maxConnections = lib.mkOption {
+                type = lib.types.int;
+                default = 10;
+              };
+            };
+            network = lib.mkOption {
+              type = lib.types.enum [ "mainnet" "preprod" "preview" "testnet" ];
+              default = "mainnet";
+            };
+            tokenRegistryUrl = lib.mkOption {
+              type = lib.types.str;
+              default = "https://tokens.cardano.org";
+            };
+          };
+        };
+        default = {};
+        description = ''
+          Freeform attrset that generates the JSON configuration file used by Blockfrost.
+         '';
+        example = ''
+          {
+            user = config.services.cardano-db-sync.postgres.user;
+            port = config.services.cardano-db-sync.postgres.port;
+            database = config.services.cardano-db-sync.postgres.database;
+            host = config.services.cardano-db-sync.postgres.socketdir;
+          }
+        '';
+      };
+      baseWorkDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/";
+        internal = true;
+      };
+      requires = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "cardano-db-sync.service" ];
+        internal = true;
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    users.users.blockfrost = lib.mkIf (cfg.user == "blockfrost") {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.stateDir;
+    };
+    users.groups.blockfrost = lib.mkIf (cfg.group == "blockfrost") { };
+
+    systemd.tmpfiles.rules = [
+      "d /etc/pm2 770 ${cfg.user} ${cfg.group}"
+    ];
+
+    systemd.services.blockfrost = {
+      inherit (cfg) requires;
+      wantedBy = [ "multi-user.target" ];
+      environment.NODE_CONFIG_RUNTIME_JSON = settingsFormat.generate "blockfrost-settings.json" cfg.settings;
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/blockfrost-backend-ryo";
+        Group = cfg.group;
+        User = cfg.user;
+        StateDirectory = lib.removePrefix cfg.baseWorkDir cfg.stateDir;
+        WorkingDirectory = cfg.stateDir;
+      };
+    };
+  };
+}


### PR DESCRIPTION
It seems to work but I haven't tested it more than `curl`ing `/health` for now, will follow updates if it doesn't work.
This assumes that whoever uses this module also enable `postgres`, `cardano-node` and `cardano-db-sync`. To do so I've used their NixOS modules (respectively from [nixpkgs](https://github.com/NixOS/nixpkgs), [cardano-node](https://github.com/input-output-hk/cardano-node) and [https://github.com/input-output-hk/cardano-db-sync](https://github.com/input-output-hk/cardano-db-sync)). I've copy/pasted a more agnostic version of my config in the README, however it's just an idea of how to use it, many parts are just comments.

It would have been possible also providing a more opinionated module where one can simply set something like `services.easy-blockfrost.enable = true` and it just works, but:

- requires more maintenance
- implies adding several new inputs to the flake

It would be nice adding a NixOS test but I don't have time to implement it in this PR.

@mmahut I remember you wanted this since #50