### PR TITLE
feat: support postgres password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- support defining a postgres password in config or env
+
 ### Fixed
 
 - bump blockfrost-utils to 2.6.2

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you are using an authenticated db connection that requires a password, you'd 
     host: 'cdbsync-dev.mydomain.com',
     user: 'username',
     database: 'password',
+    // Optionally define a password
+    password: 'randomstringthatissolongandpowerfulthatnoonecanguess'
   },
   // Cardano network - mainnet, testnet, preview, preprod
   network: 'mainnet',
@@ -179,7 +181,7 @@ A minimal usage example is:
         database = config.services.cardano-db-sync.postgres.database;
         host = config.services.cardano-db-sync.postgres.socketdir;
       };
-    };      
+    };
   };
 }
 ```

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,7 @@ const start = (options = {}): FastifyInstance => {
     user: config.dbSync.user,
     database: config.dbSync.database,
     max: config.dbSync.maxConnections,
+    password: config.dbSync.password,
   });
 
   // addresses

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,9 @@ export const loadConfig = () => {
     Number(process.env.BLOCKFROST_CONFIG_DBSYNC_PORT) ?? config.get<number>('dbSync.port');
   const databaseSyncDatabase =
     process.env.BLOCKFROST_CONFIG_DBSYNC_DATABASE ?? config.get<string>('dbSync.database');
+  const databaseSyncPassword =
+    process.env.BLOCKFROST_CONFIG_DBSYNC_PASSWORD ??
+    (config.has('dbSync.password') ? config.get('dbSync.password') : undefined);
   const databaseSyncMaxConnections = process.env.BLOCKFROST_CONFIG_DBSYNC_MAX_CONN
     ? Number(process.env.BLOCKFROST_CONFIG_DBSYNC_MAX_CONN)
     : config.get<number>('dbSync.maxConnections');
@@ -53,6 +56,7 @@ export const loadConfig = () => {
       host: databaseSyncHost,
       port: databaseSyncPort,
       user: databaseSyncUser,
+      password: databaseSyncPassword,
       database: databaseSyncDatabase,
       maxConnections: databaseSyncMaxConnections,
     },


### PR DESCRIPTION
Adds support for optionally defining a Postgres password. The alternative to checking if the config has the value would be to consider an empty string `''` or `nil` as no password. Let me know if this would be preferable