### PR TITLE
fix: enable prometheus endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NodeJS updated to `18.16.1`
 - README config example
 - shell.nix default to Node 18
+- registered missing /prometheus endpoint
 
 ## [1.6.0] - 2023-06-28
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -148,6 +148,7 @@ const start = (options = {}): FastifyInstance => {
 
   // root
   registerRoute(app, import('./routes/root/index.js'));
+  registerRoute(app, import('./routes/root/prometheus.js'));
 
   // scripts
   registerRoute(app, import('./routes/scripts/index.js'));


### PR DESCRIPTION
Adds a missing route registration for the `/prometheus` endpoint and includes the relevant changelog entry.