### PR TITLE
fix(sql): ordering where sorted_limited is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ordering in `/assets/asset/txs`, `/assets/asset/transactions` and `/epochs/{number}/stakes`
 - port configuration via config option `dbSync.port`
 - error in `/epochs/n/parameters` for epochs without PlutusV1/PlutusV2 cost models
 

--- a/src/sql/assets/assets_asset_transactions.sql
+++ b/src/sql/assets/assets_asset_transactions.sql
@@ -37,3 +37,10 @@ FROM (
   ) AS "sorted_limited"
   JOIN tx ON (sorted_limited.tx_id = tx.id)
   JOIN block b ON (b.id = tx.block_id)
+    ORDER BY CASE
+    WHEN LOWER($1) = 'desc' THEN sorted_limited.tx_id
+  END DESC,
+  CASE
+    WHEN LOWER($1) <> 'desc'
+    OR $1 IS NULL THEN sorted_limited.tx_id
+  END ASC

--- a/src/sql/assets/assets_asset_txs.sql
+++ b/src/sql/assets/assets_asset_txs.sql
@@ -30,3 +30,10 @@ FROM (
       END
   ) AS "sorted_limited"
   JOIN tx ON (sorted_limited.tx_id = tx.id)
+  ORDER BY CASE
+    WHEN LOWER($1) = 'desc' THEN sorted_limited.tx_id
+  END DESC,
+  CASE
+    WHEN LOWER($1) <> 'desc'
+    OR $1 IS NULL THEN sorted_limited.tx_id
+  END ASC

--- a/src/sql/epochs/epochs_number_stakes.sql
+++ b/src/sql/epochs/epochs_number_stakes.sql
@@ -2,7 +2,8 @@ SELECT sa.view AS "stake_address",
   ph.view AS "pool_id",
   sorted_limited.amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow
 FROM(
-    SELECT es.amount AS "amount",
+    SELECT es.id,
+      es.amount AS "amount",
       es.addr_id,
       es.pool_id
     FROM epoch_stake es
@@ -26,3 +27,4 @@ FROM(
   ) AS "sorted_limited"
   JOIN pool_hash ph ON (ph.id = sorted_limited.pool_id)
   JOIN stake_address sa ON (sorted_limited.addr_id = sa.id)
+ORDER BY sorted_limited.id ASC


### PR DESCRIPTION
Fixes https://github.com/blockfrost/blockfrost-backend-ryo/issues/144

When using `sorted_limited` improvement, data needs to be re-ordered by id in the outer select as well, to maintain fixed ordering at all times.