### PR TITLE
fix(sql): don't render asset in collateral utxo output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - port configuration via config option `dbSync.port`
 - live_stake for retired pools in `/pools/{pool_id}` was always 0, instead of displaying the delegated amount
 - `metadata/txs/labels/:num` and `/scripts/:hash/json` json encoding for primitive types (eg. string) (`@blockfrost/openapi` 0.1.62)
+- `/txs/{hash}/utxos` rendering of wrong asset in collateral output [#161](https://github.com/blockfrost/blockfrost-backend-ryo/pull/161)
 
 
 ## [1.7.0] - 2023-08-30

--- a/src/sql/txs/txs_hash_utxos_1.sql
+++ b/src/sql/txs/txs_hash_utxos_1.sql
@@ -1,6 +1,6 @@
 SELECT *
 FROM (
--- normal inputs
+    -- normal inputs
     SELECT txi.id AS "tx_in_id",
       txo.address AS "address",
       encode(tx2.hash, 'hex') AS "tx_hash", -- output hash of previous UTxO
@@ -32,7 +32,8 @@ FROM (
       )
       JOIN tx tx2 ON (txi.tx_out_id = tx2.id)
       LEFT JOIN datum dat ON (txo.inline_datum_id = dat.id)
-    WHERE encode(tx.hash, 'hex') = $1 -- UNION with reference inputs
+    WHERE encode(tx.hash, 'hex') = $1
+    -- UNION with reference inputs
     UNION ALL
     SELECT rtxi.id AS "tx_in_id",
       txo.address AS "address",
@@ -66,7 +67,8 @@ FROM (
       JOIN tx tx2 ON (rtxi.tx_out_id = tx2.id)
       LEFT JOIN datum dat ON (txo.inline_datum_id = dat.id)
       LEFT JOIN script scr ON (txo.reference_script_id = scr.id)
-    WHERE encode(tx.hash, 'hex') = $1 -- UNION with collateral inputs
+    WHERE encode(tx.hash, 'hex') = $1
+    -- UNION with collateral inputs
     UNION ALL
     SELECT ctxi.id AS "tx_in_id",
       txo.address AS "address",

--- a/src/sql/txs/txs_hash_utxos_2.sql
+++ b/src/sql/txs/txs_hash_utxos_2.sql
@@ -25,7 +25,8 @@ FROM (
       JOIN tx_out txo ON (txo.tx_id = tx.id)
       LEFT JOIN datum dat ON (txo.inline_datum_id = dat.id)
       LEFT JOIN script scr ON (txo.reference_script_id = scr.id)
-    WHERE encode(tx.hash, 'hex') = $1 -- UNION with collateral outputs
+    WHERE encode(tx.hash, 'hex') = $1
+    -- UNION with collateral outputs
     UNION ALL
     SELECT txo.address AS "address",
       txo.value::TEXT AS "amount_lovelace",

--- a/src/sql/txs/txs_hash_utxos_2.sql
+++ b/src/sql/txs/txs_hash_utxos_2.sql
@@ -30,20 +30,7 @@ FROM (
     UNION ALL
     SELECT txo.address AS "address",
       txo.value::TEXT AS "amount_lovelace",
-      -- cast to TEXT to avoid number overflow
-      (
-        SELECT json_agg(
-            json_build_object(
-              'unit',
-              CONCAT(encode(policy, 'hex'), encode(name, 'hex')),
-              'quantity',
-              mto.quantity::TEXT -- cast to TEXT to avoid number overflow
-            )
-          )
-        FROM ma_tx_out mto
-          JOIN multi_asset ma ON (mto.ident = ma.id)
-        WHERE mto.tx_out_id = txo.id
-      ) AS "amount",
+      null AS "amount",
       encode(txo.data_hash, 'hex') AS "data_hash",
       encode(dat.bytes, 'hex') AS "inline_datum",
       true AS "collateral",


### PR DESCRIPTION
Correct asset is part of normal output. The asset in output collateral
is completely wrong and it should only contain ADA value. This aligns
it with input UTXOs.

Closes https://github.com/blockfrost/blockfrost-backend-ryo/issues/160