### PR TITLE
fix: use coins_per_utxo_size with a fallback to min_utxo_value as min…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - live_stake for retired pools in `/pools/{pool_id}` was always 0, instead of displaying the delegated amount
 - `metadata/txs/labels/:num` and `/scripts/:hash/json` json encoding for primitive types (eg. string) (`@blockfrost/openapi` 0.1.62)
 - `/txs/{hash}/utxos` rendering of wrong asset in collateral output [#161](https://github.com/blockfrost/blockfrost-backend-ryo/pull/161)
+- In `/epochs/:num/parameters` set `min_utxo` to `coins_per_utxo_size` with a fallback to `min_utxo_value` if `coins_per_utxo_size` is null
 
 
 ## [1.7.0] - 2023-08-30

--- a/src/sql/epochs/epochs_latest_parameters.sql
+++ b/src/sql/epochs/epochs_latest_parameters.sql
@@ -15,7 +15,7 @@ SELECT epoch_no AS "epoch",
   extra_entropy AS "extra_entropy",
   protocol_major AS "protocol_major_ver",
   protocol_minor AS "protocol_minor_ver",
-  min_utxo_value::TEXT AS "min_utxo", -- cast to TEXT to avoid number overflow
+  COALESCE(coins_per_utxo_size, min_utxo_value)::TEXT AS "min_utxo", -- cast to TEXT to avoid number overflow; DEPRECATED since Alonzo, uses coins_per_utxo_size for backwards compatibility despite dbsync 13.2+ setting this to 0
   min_pool_cost::TEXT AS "min_pool_cost", -- cast to TEXT to avoid number overflow
   encode(nonce, 'hex') AS "nonce",
   cm.costs AS "cost_models",

--- a/src/sql/epochs/epochs_number_parameters.sql
+++ b/src/sql/epochs/epochs_number_parameters.sql
@@ -15,7 +15,7 @@ SELECT epoch_no AS "epoch",
   extra_entropy AS "extra_entropy",
   protocol_major AS "protocol_major_ver",
   protocol_minor AS "protocol_minor_ver",
-  min_utxo_value::TEXT AS "min_utxo", -- cast to TEXT to avoid number overflow
+  COALESCE(coins_per_utxo_size, min_utxo_value)::TEXT AS "min_utxo", -- cast to TEXT to avoid number overflow; DEPRECATED since Alonzo, uses coins_per_utxo_size for backwards compatibility despite dbsync 13.2+ setting this to 0
   min_pool_cost::TEXT AS "min_pool_cost", -- cast to TEXT to avoid number overflow
   encode(nonce, 'hex') AS "nonce",
   cm.costs AS "cost_models",


### PR DESCRIPTION
…_utxo

new version of db_sync no longer updates `min_utxo_value`

close https://github.com/blockfrost/blockfrost-backend-ryo/issues/163