### PR TITLE
fix(pools): live saturation calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- calculation of `live_saturation` in `/pools/{pool_id}` as although ledger specifies the variable as circulating supply, total supply (45B-reserves) is used in this calculation instead
+
 ## [2.0.1] - 2024-04-08
 
 | :warning: WARNING                                                                                                                |


### PR DESCRIPTION
This PR fixes calculation of `live_saturation` in `/pools/{pool_id}`. Although ledger specifies the variable as circulating supply, total supply (`45B - reserves`) is used in this calculation instead.