### PR TITLE
fix(pools): live stake calculation of delegators with MIRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- calculation of `live_stake` in `/pools/{pool_id}/delegators` to reflect the split of MIRs into a separate table (`instant_reward`) in new dbsync, which was omitted in 2.0.1 for this endpoint
+
 ## [2.0.2] - 2024-05-09
 
 ### Fixed

--- a/src/sql/pools/pools_pool_id_delegators.sql
+++ b/src/sql/pools/pools_pool_id_delegators.sql
@@ -21,6 +21,14 @@ SELECT "address" AS "address",
           SELECT *
           FROM current_epoch
         )
+    ) + (
+      SELECT COALESCE(SUM(amount), 0)
+      FROM instant_reward ir
+      WHERE (ir.addr_id = address_id)
+        AND ir.spendable_epoch <= (
+          SELECT *
+          FROM current_epoch
+        )
     ) - (
       SELECT COALESCE(SUM(amount), 0)
       FROM withdrawal w


### PR DESCRIPTION
Fixes calculation of `live_stake` in `/pools/{pool_id}/delegators` to reflect the split of MIRs into a separate table (`instant_reward`) in new dbsync, which was omitted in 2.0.1 for this endpoint