### PR TITLE
fix(addresses): payment_cred stake_address: null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded Fastify dependencies
 - Upgraded Typescript
 
+### Fixed
+
+- `/addresses/{payment_cred}` and `/addresses/{payment_cred}/extended` to always show `stake_address: null`
+
 ## [2.0.3] - 2024-05-23
 
 ### Fixed

--- a/src/sql/addresses/addresses_address.sql
+++ b/src/sql/addresses/addresses_address.sql
@@ -1,11 +1,6 @@
 WITH queried_address AS (
   SELECT CASE
-      WHEN $2::BYTEA IS NOT NULL THEN (
-        SELECT stake_address_id AS "stake_address_id"
-        FROM tx_out txo
-        WHERE txo.payment_cred = $2
-        LIMIT 1
-      )
+      WHEN $2::BYTEA IS NOT NULL THEN (0)
       ELSE (
         SELECT stake_address_id AS "stake_address_id"
         FROM tx_out txo

--- a/src/sql/addresses/addresses_address_extended.sql
+++ b/src/sql/addresses/addresses_address_extended.sql
@@ -1,11 +1,6 @@
 WITH queried_address AS (
   SELECT CASE
-      WHEN $2::BYTEA IS NOT NULL THEN (
-        SELECT stake_address_id AS "stake_address_id"
-        FROM tx_out txo
-        WHERE txo.payment_cred = $2
-        LIMIT 1
-      )
+      WHEN $2::BYTEA IS NOT NULL THEN (0)
       ELSE (
         SELECT stake_address_id AS "stake_address_id"
         FROM tx_out txo


### PR DESCRIPTION
Previously, first queried stake address was displayed. But since tthere can be multiple stake addresses for a given payment_cred, this information was not correct. The fix is to always display `null` instead of a random stake_address.

Testing vector:
http://localhost:3000/addresses/addr_vkh1vt2ntv45rx6e7rfk2qfw2434kdnl0k8fl4h3h6p55d2j6k6czz3

Current state:

```
{
  "address": "addr_vkh1vt2ntv45rx6e7rfk2qfw2434kdnl0k8fl4h3h6p55d2j6k6czz3",
  "amount": [
    {
      "unit": "lovelace",
      "quantity": "20000000"
    }
  ],
  "stake_address": "stake_test1upnhn29zpdwaje5myechf05094s4crp04vnzusqlwg59f4qjx6t73",
  "type": "shelley",
  "script": false
}
```


This PR:
```
{
  "address": "addr_vkh1vt2ntv45rx6e7rfk2qfw2434kdnl0k8fl4h3h6p55d2j6k6czz3",
  "amount": [
    {
      "unit": "lovelace",
      "quantity": "20000000"
    }
  ],
  "stake_address": null,
  "type": "shelley",
  "script": false
}
```