### PR TITLE
fix(scripts): ordering (internal id instead of tx_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded Fastify dependencies
 - Upgraded Typescript
 
+### Fixed
+
+- ordering in `/scripts`
+
 ## [2.0.3] - 2024-05-23
 
 ### Fixed

--- a/src/sql/scripts/scripts.sql
+++ b/src/sql/scripts/scripts.sql
@@ -1,11 +1,11 @@
 SELECT encode(s.hash, 'hex') AS "script_hash"
 FROM script s
 ORDER BY CASE
-    WHEN LOWER($1) = 'desc' THEN s.tx_id
+    WHEN LOWER($1) = 'desc' THEN s.id
   END DESC,
   CASE
     WHEN LOWER($1) <> 'desc'
-    OR $1 IS NULL THEN s.tx_id
+    OR $1 IS NULL THEN s.id
   END ASC
 LIMIT CASE
     WHEN $2 >= 1

--- a/src/sql/scripts/unpaged/scripts.sql
+++ b/src/sql/scripts/unpaged/scripts.sql
@@ -1,9 +1,9 @@
 SELECT encode(s.hash, 'hex') AS "script_hash"
 FROM script s
 ORDER BY CASE
-    WHEN LOWER($1) = 'desc' THEN s.tx_id
+    WHEN LOWER($1) = 'desc' THEN s.id
   END DESC,
   CASE
     WHEN LOWER($1) <> 'desc'
-    OR $1 IS NULL THEN s.tx_id
+    OR $1 IS NULL THEN s.id
   END ASC


### PR DESCRIPTION
Since there can be multiple scripts with the same `tx_id` it is not enough to order them by this column - change to internal `id` fixes the inconsistency issue.