### PR TITLE
fix: off_chain_pool_data join on pmr_id instead of hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Plutus V3 cost model mapping
+- `/pools/{pool_id}/metadata`, `/txs/{hash}/pool_updates` returning multiple rows
 
 ## [2.1.0] - 2024-07-31
 

--- a/src/sql/pools/pools_pool_id_metadata.sql
+++ b/src/sql/pools/pools_pool_id_metadata.sql
@@ -19,7 +19,7 @@ SELECT (
   pod.ticker_name AS "ticker",
   pod.json AS "metadata_text"
 FROM pool_metadata_ref pmr
-  LEFT JOIN off_chain_pool_data pod ON (pmr.hash = pod.hash)
+  LEFT JOIN off_chain_pool_data pod ON (pod.pmr_id = pmr.id)
 WHERE pmr.id = (
     SELECT meta_id
     FROM pool_update pu

--- a/src/sql/txs/txs_hash_pool_updates.sql
+++ b/src/sql/txs/txs_hash_pool_updates.sql
@@ -27,6 +27,6 @@ FROM tx
   JOIN pool_hash ph ON (ph.id = pu.hash_id)
   LEFT JOIN stake_address sa ON (sa.id = pu.reward_addr_id)
   LEFT JOIN pool_metadata_ref pmr ON (pmr.id = pu.meta_id)
-  LEFT JOIN off_chain_pool_data pod ON (pmr.hash = pod.hash)
+  LEFT JOIN off_chain_pool_data pod ON (pod.pmr_id = pmr.id)
 WHERE encode(tx.hash, 'hex') = $1
 ORDER BY pu.cert_index ASC


### PR DESCRIPTION
Since joining on hash can produce multiple rows in case there were multiple pool registrations using the same metadata (same hash).