### PR TITLE
feat(governance): optimize UTxO subquery using `consumed_by_tx`

### DIFF
--- a/src/sql/governance/dreps_drep_id_delegators.sql
+++ b/src/sql/governance/dreps_drep_id_delegators.sql
@@ -9,9 +9,7 @@ SELECT "address" AS "address",
     (
       SELECT COALESCE(SUM(txo.value), 0)
       FROM tx_out txo
-        LEFT JOIN tx_in txi ON (txo.tx_id = txi.tx_out_id)
-        AND (txo.index = txi.tx_out_index)
-      WHERE txi IS NULL
+      WHERE txo.consumed_by_tx_id IS NULL
         AND txo.stake_address_id = address_id
     ) + (
       SELECT COALESCE(SUM(amount), 0)


### PR DESCRIPTION
Instead of using `JOIN` on `txi` and looking for `null txi`, we leverage `consumed_by_tx` enabled by `cardano-db-sync`s [insert option `tx_out.value = "consumed"`](https://github.com/IntersectMBO/cardano-db-sync/blob/08f82fcd942c77a7b1baf28d026713d86f7267fd/doc/configuration.md#value)