### PR TITLE
fix: looser validation for cost model size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- looser validation for cost model size
+
 ## [2.4.0] - 2024-11-20
 
 ### Added

--- a/src/utils/cost-models-map.ts
+++ b/src/utils/cost-models-map.ts
@@ -665,16 +665,16 @@ export const costModelsMap = (costModels: any) => {
 
   costModels = sortKeysInObject(costModels);
 
-  if ('PlutusV1' in costModels && Object.keys(costModels.PlutusV1).length !== plutusV1Names.length)
+  if ('PlutusV1' in costModels && Object.keys(costModels.PlutusV1).length < plutusV1Names.length)
     throw new Error('The size of the Plutus V1 cost model mismatched');
 
-  if ('PlutusV2' in costModels && Object.keys(costModels.PlutusV2).length !== plutusV2Names.length)
+  if ('PlutusV2' in costModels && Object.keys(costModels.PlutusV2).length < plutusV2Names.length)
     throw new Error('The size of the Plutus V2 cost model mismatched');
 
   if (
     'PlutusV3' in costModels &&
     Object.keys(costModels.PlutusV3).length !== plutusV3Names.length &&
-    Object.keys(costModels.PlutusV3).length !== plutusV3NamesChangPlus1.length
+    Object.keys(costModels.PlutusV3).length < plutusV3NamesChangPlus1.length
   )
     throw new Error('The size of the Plutus V3 cost model mismatched');
 


### PR DESCRIPTION
based on https://github.com/mkazlauskas/blockfrost-backend-ryo/commit/9e5ea8f60f9701005a022b4f5591a7a06c698797