### PR TITLE
CIP-0129 drep ids

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
     'unicorn/prefer-ternary': 0,
     'unicorn/no-null': 'off',
     'no-nested-ternary': 'off',
+    'unicorn/number-literal-case': 'off',
     'unicorn/prevent-abbreviations': [
       'error',
       {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = {
           CardanoDbSync: true,
           getDbSync: true,
           clientDbSync: true,
+          dbSyncDRepToCIP129: true,
         },
       },
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for CIP129 DRep ID - you can query DReps using both legacy format and CIP129 format. The `drep_id` and `hex` fields will reflect the format of the query param
+
 ### Changed
 
-- looser validation for cost model size
+- BREAKING CHANGE: Endpoints `/governance/dreps` and `/governance/proposals/{tx_hash}/{cert_index}/votes` are now using CIP129 format
+- Looser validation for cost model size in `epochs/:num/parameters`
 
 ## [2.4.0] - 2024-11-20
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@blockfrost/blockfrost-js": "5.5.0",
     "@blockfrost/blockfrost-utils": "2.8.1",
     "@blockfrost/openapi": "0.1.69",
-    "@emurgo/cardano-serialization-lib-nodejs": "11.5.0",
     "@fastify/cors": "^9.0.1",
     "@fastify/http-proxy": "^9.5.0",
     "@fastify/postgres": "^5.2.2",

--- a/src/routes/governance/dreps/drep-id/delegators.ts
+++ b/src/routes/governance/dreps/drep-id/delegators.ts
@@ -6,7 +6,7 @@ import { SQLQuery } from '../../../../sql/index.js';
 import { getSchemaForEndpoint } from '@blockfrost/openapi';
 import { isUnpaged } from '../../../../utils/routes.js';
 import { handle400Custom } from '@blockfrost/blockfrost-utils/lib/fastify.js';
-import { validateDRepId } from '../../../../utils/validation.js';
+import { validateDRepId } from '../../../../utils/governance.js';
 
 async function route(fastify: FastifyInstance) {
   fastify.route({
@@ -32,9 +32,9 @@ async function route(fastify: FastifyInstance) {
               SQLQuery.get('governance_dreps_drep_id_delegators_unpaged'),
               [
                 request.query.order,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             )
           : await clientDbSync.query<QueryTypes.DRepsDrepIDDelegators>(
@@ -43,9 +43,9 @@ async function route(fastify: FastifyInstance) {
                 request.query.order,
                 request.query.count,
                 request.query.page,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             );
 

--- a/src/routes/governance/dreps/drep-id/metadata.ts
+++ b/src/routes/governance/dreps/drep-id/metadata.ts
@@ -5,7 +5,7 @@ import { getDbSync, gracefulRelease } from '../../../../utils/database.js';
 import { handle400Custom, handle404 } from '../../../../utils/error-handler.js';
 import { SQLQuery } from '../../../../sql/index.js';
 import { getSchemaForEndpoint } from '@blockfrost/openapi';
-import { validateDRepId } from '../../../../utils/validation.js';
+import { validateDRepId, enhanceDRep } from '../../../../utils/governance.js';
 
 async function route(fastify: FastifyInstance) {
   fastify.route({
@@ -28,7 +28,7 @@ async function route(fastify: FastifyInstance) {
         const { rows }: { rows: ResponseTypes.DRepsDrepIDMetadata[] } =
           await clientDbSync.query<QueryTypes.DRepsDrepIDMetadata>(
             SQLQuery.get('governance_dreps_drep_id_metadata'),
-            [drepValidation.raw, drepValidation.id, drepValidation.hasScript],
+            [drepValidation.dbSync.raw, drepValidation.dbSync.id, drepValidation.dbSync.hasScript],
           );
 
         gracefulRelease(clientDbSync);
@@ -38,7 +38,10 @@ async function route(fastify: FastifyInstance) {
         if (!row) {
           return handle404(reply);
         }
-        return reply.send(row);
+
+        const data = enhanceDRep(row, drepValidation);
+
+        return reply.send(data);
       } catch (error) {
         gracefulRelease(clientDbSync);
         throw error;

--- a/src/routes/governance/dreps/drep-id/updates.ts
+++ b/src/routes/governance/dreps/drep-id/updates.ts
@@ -6,7 +6,7 @@ import { SQLQuery } from '../../../../sql/index.js';
 import { getSchemaForEndpoint } from '@blockfrost/openapi';
 import { isUnpaged } from '../../../../utils/routes.js';
 import { handle400Custom } from '@blockfrost/blockfrost-utils/lib/fastify.js';
-import { validateDRepId } from '../../../../utils/validation.js';
+import { validateDRepId } from '../../../../utils/governance.js';
 
 async function route(fastify: FastifyInstance) {
   fastify.route({
@@ -32,9 +32,9 @@ async function route(fastify: FastifyInstance) {
               SQLQuery.get('governance_dreps_drep_id_updates_unpaged'),
               [
                 request.query.order,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             )
           : await clientDbSync.query<QueryTypes.DRepsDrepIDUpdates>(
@@ -43,9 +43,9 @@ async function route(fastify: FastifyInstance) {
                 request.query.order,
                 request.query.count,
                 request.query.page,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             );
 

--- a/src/routes/governance/dreps/drep-id/votes.ts
+++ b/src/routes/governance/dreps/drep-id/votes.ts
@@ -6,7 +6,7 @@ import { SQLQuery } from '../../../../sql/index.js';
 import { getSchemaForEndpoint } from '@blockfrost/openapi';
 import { isUnpaged } from '../../../../utils/routes.js';
 import { handle400Custom } from '@blockfrost/blockfrost-utils/lib/fastify.js';
-import { validateDRepId } from '../../../../utils/validation.js';
+import { validateDRepId } from '../../../../utils/governance.js';
 
 async function route(fastify: FastifyInstance) {
   fastify.route({
@@ -32,9 +32,9 @@ async function route(fastify: FastifyInstance) {
               SQLQuery.get('governance_dreps_drep_id_votes_unpaged'),
               [
                 request.query.order,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             )
           : await clientDbSync.query<QueryTypes.DRepsDrepIDUpdates>(
@@ -43,9 +43,9 @@ async function route(fastify: FastifyInstance) {
                 request.query.order,
                 request.query.count,
                 request.query.page,
-                drepValidation.raw,
-                drepValidation.id,
-                drepValidation.hasScript,
+                drepValidation.dbSync.raw,
+                drepValidation.dbSync.id,
+                drepValidation.dbSync.hasScript,
               ],
             );
 

--- a/src/routes/governance/dreps/index.ts
+++ b/src/routes/governance/dreps/index.ts
@@ -28,6 +28,8 @@ async function route(fastify: FastifyInstance) {
 
         gracefulRelease(clientDbSync);
 
+        // TODO: how to handle cip-0129 in list of dreps?
+
         return reply.send(rows);
       } catch (error) {
         gracefulRelease(clientDbSync);

--- a/src/routes/governance/proposals/tx-hash/cert-index/votes.ts
+++ b/src/routes/governance/proposals/tx-hash/cert-index/votes.ts
@@ -37,7 +37,12 @@ async function route(fastify: FastifyInstance) {
         gracefulRelease(clientDbSync);
 
         for (const row of rows) {
-          // Convert voter id to cip129 format
+          if (!row.voter.startsWith('drep')) {
+            // Keep non-DRep voter unmodified
+            continue;
+          }
+
+          // Convert voter id to CIP129 format
           const cip129DRep = dbSyncDRepToCIP129({
             drep_id: row.voter,
             has_script: row.voter_has_script,

--- a/src/routes/governance/proposals/tx-hash/cert-index/votes.ts
+++ b/src/routes/governance/proposals/tx-hash/cert-index/votes.ts
@@ -35,6 +35,7 @@ async function route(fastify: FastifyInstance) {
 
         gracefulRelease(clientDbSync);
 
+        // TODO: CIP-0129 compatible voter field
         return reply.send(rows);
       } catch (error) {
         gracefulRelease(clientDbSync);

--- a/src/sql/governance/dreps.sql
+++ b/src/sql/governance/dreps.sql
@@ -1,5 +1,7 @@
-SELECT dh.view AS "drep_id",
-  encode(dh.raw, 'hex') AS "hex"
+SELECT 
+  dh.view AS "drep_id",
+  encode(dh.raw, 'hex') AS "hex",
+  dh.has_script AS "has_script"
 FROM drep_hash dh
 ORDER BY CASE
     WHEN LOWER($1) = 'desc' THEN dh.id

--- a/src/sql/governance/proposals_proposal_votes.sql
+++ b/src/sql/governance/proposals_proposal_votes.sql
@@ -17,6 +17,7 @@ SELECT encode(tx.hash, 'hex') AS "tx_hash",
   (
     COALESCE(encode(ch.raw, 'hex'), dh.view, ph.view)
   ) AS "voter",
+  dh.has_script AS "voter_has_script",
   LOWER(vote::TEXT) AS "vote" -- Yes, No, Abstain -> yes,no,abstain
 FROM voting_procedure vp
   JOIN gov_action_proposal gap ON (gap.id = vp.gov_action_proposal_id)

--- a/src/sql/governance/unpaged/dreps.sql
+++ b/src/sql/governance/unpaged/dreps.sql
@@ -1,5 +1,6 @@
 SELECT dh.view AS "drep_id",
-  encode(dh.raw, 'hex') AS "hex"
+  encode(dh.raw, 'hex') AS "hex",
+  dh.has_script AS "has_script"
 FROM drep_hash dh
 ORDER BY CASE
     WHEN LOWER($1) = 'desc' THEN dh.id

--- a/src/sql/governance/unpaged/proposals_proposal_votes.sql
+++ b/src/sql/governance/unpaged/proposals_proposal_votes.sql
@@ -17,6 +17,7 @@ SELECT encode(tx.hash, 'hex') AS "tx_hash",
   (
     COALESCE(encode(ch.raw, 'hex'), dh.view, ph.view)
   ) AS "voter",
+  dh.has_script AS "voter_has_script",
   LOWER(vote::TEXT) AS "vote" -- Yes, No, Abstain -> yes,no,abstain
 FROM voting_procedure vp
   JOIN gov_action_proposal gap ON (gap.id = vp.gov_action_proposal_id)

--- a/src/types/queries/governance.ts
+++ b/src/types/queries/governance.ts
@@ -27,6 +27,7 @@ export interface RequestDRepID {
 export interface DReps {
   drep_id: string;
   hex: string;
+  has_script: boolean;
 }
 
 export interface DRepsDrepID {
@@ -142,6 +143,7 @@ export interface ProposalsProposalVotes {
   cert_index: number;
   voter_role: 'constitutional_committee' | 'drep' | 'spo';
   voter: string;
+  voter_has_script: boolean;
   vote: 'yes' | 'no' | 'abstain';
 }
 

--- a/src/utils/governance.ts
+++ b/src/utils/governance.ts
@@ -1,0 +1,176 @@
+import { bech32 } from 'bech32';
+
+export interface DRepValidationResult {
+  // TODO: maybe rename to raw, raw prop to hex,
+  dbSync: {
+    id: string;
+    raw: string | null;
+    hasScript: boolean;
+  };
+  // cip129 is set when the bechDrepId
+  cip129: {
+    // CIP129 bech32 representation of dRep ID
+    id: string;
+    // CIP129 hex representation of dRep ID (includes 1 byte header)
+    hex: string | null;
+  };
+  isCip129: boolean;
+}
+
+/**
+ * Validates a DRep ID and returns both the ID and its raw format if applicable.
+ *
+ * @param {string} bechDrepId - The DRep ID in Bech32 format that needs to be validated.
+ * @returns {{ id: string, raw: string | null }} - An object containing the validated ID and its raw form.
+ *   - `id`: The original DRep ID.
+ *   - `raw`: The raw format of the DRep ID in hexadecimal if applicable, or `null` for special cases (drep_always_abstain, drep_always_no_confidence).
+ *
+ * @throws {Error} If the DRep ID prefix is invalid, an error is thrown.
+ */
+export const validateDRepId = (bechDrepId: string): DRepValidationResult => {
+  const SPECIAL_DREP_IDS = ['drep_always_abstain', 'drep_always_no_confidence'];
+
+  if (SPECIAL_DREP_IDS.includes(bechDrepId)) {
+    return {
+      dbSync: {
+        id: bechDrepId,
+        raw: null,
+        hasScript: false,
+      },
+      cip129: {
+        id: bechDrepId,
+        hex: null,
+      },
+      isCip129: false,
+    };
+  }
+  const { prefix, words } = bech32.decode(bechDrepId);
+
+  if (prefix !== 'drep' && prefix !== 'drep_script') {
+    throw new Error('Invalid drep id prefix');
+  }
+
+  const hexBuf = Buffer.from(bech32.fromWords(words));
+
+  if (hexBuf.length === 28) {
+    // 28 bytes of keyHash/scriptHash
+    // Legacy dbSync-compatible format
+    const drepIdRaw = `\\x${hexBuf.toString('hex')}`;
+
+    const hasScript = prefix === 'drep_script';
+
+    const keyTypeNibble = 0x2 << 4; // set keyType to dRep
+    const credentialTypeNibble = hasScript ? 0x3 : 0x2;
+
+    const header = keyTypeNibble | credentialTypeNibble;
+
+    const headerBuff = Buffer.alloc(1); // Allocate a 1-byte buffer (adjust size as needed)
+
+    headerBuff.writeUInt8(header, 0);
+
+    const hexWithHeader = Buffer.concat([headerBuff, hexBuf]);
+    const idWithHeader = bech32.encode('drep', bech32.toWords(hexWithHeader));
+
+    return {
+      dbSync: {
+        id: bechDrepId,
+        raw: drepIdRaw,
+        hasScript: hasScript,
+      },
+      cip129: {
+        id: idWithHeader,
+        hex: hexWithHeader.toString('hex'),
+      },
+      isCip129: false,
+    };
+  } else {
+    // CIP-0129 with 1-byte header
+    // Extract the first byte
+    const headerByte = hexBuf[0];
+
+    // Decode the first nibble (4 bits) for key type
+    const keyTypeNibble = (headerByte >> 4) & 0x0f;
+    let keyType: 'cc_hot' | 'cc_cold' | 'drep';
+
+    switch (keyTypeNibble) {
+      case 0x0: {
+        keyType = 'cc_hot'; // Hot Credential
+        break;
+      }
+      case 0x1: {
+        keyType = 'cc_cold'; // Cold Credential
+        break;
+      }
+      case 0x2: {
+        keyType = 'drep'; // Delegation Representative
+        break;
+      }
+      default: {
+        throw new Error('Invalid key type in header');
+      }
+    }
+
+    if (keyType !== 'drep') {
+      throw new Error('Invalid key type in header for dRep');
+    }
+
+    // Decode the second nibble (4 bits) for credential type
+    const credentialTypeNibble = headerByte & 0x0f;
+    let credentialType: 'keyHash' | 'scriptHash';
+
+    switch (credentialTypeNibble) {
+      case 0x2: {
+        credentialType = 'keyHash'; // Key Hash Credential
+        break;
+      }
+      case 0x3: {
+        credentialType = 'scriptHash'; // Script Hash Credential
+        break;
+      }
+      default: {
+        throw new Error('Invalid credential type in header');
+      }
+    }
+
+    // Extract the rest of the buffer (excluding the header byte)
+    const drepIdRaw = hexBuf.subarray(1).toString('hex');
+
+    const legacyBech32 = bech32.encode('drep', bech32.toWords(hexBuf.subarray(1)));
+
+    return {
+      dbSync: {
+        id: legacyBech32,
+        raw: `\\x${drepIdRaw}`,
+        hasScript: credentialType === 'scriptHash',
+      },
+      cip129: {
+        id: bechDrepId,
+        hex: hexBuf.toString('hex'),
+      },
+      isCip129: true,
+    };
+  }
+};
+
+/**
+ * Transform DRep dbsync data to CIP-0129 format if necessary
+ *
+ * @param {{drep_id: string; hex: string}} data - DRep dbsync data
+ * @returns Object - DRep data object with CIP-0129 compatible bech32 ID and hex in case of CIP-0129 drepId. Otherwise the data remain unmodified.
+ *
+ * @throws {Error} If the DRep ID prefix is invalid, an error is thrown.
+ */
+export const enhanceDRep = <T extends { drep_id: string; hex: string }>(
+  data: T,
+  dRepValidationResult: DRepValidationResult,
+) => {
+  if (dRepValidationResult.isCip129) {
+    return {
+      ...data,
+      drep_id: dRepValidationResult.cip129.id,
+      hex: dRepValidationResult.cip129.hex,
+    };
+  } else {
+    return data;
+  }
+};

--- a/src/utils/governance.ts
+++ b/src/utils/governance.ts
@@ -38,13 +38,11 @@ export const dbSyncDRepToCIP129 = <T extends { drep_id: string; has_script: bool
 };
 
 export interface DRepValidationResult {
-  // TODO: maybe rename to raw, raw prop to hex,
   dbSync: {
     id: string;
     raw: string | null;
     hasScript: boolean;
   };
-  // cip129 is set when the bechDrepId
   cip129: {
     // CIP129 bech32 representation of dRep ID
     id: string;
@@ -183,7 +181,6 @@ export const validateDRepId = (bechDrepId: string): DRepValidationResult => {
  * @param {{drep_id: string; hex: string}} data - DRep dbsync data
  * @returns Object - DRep data object with CIP-0129 compatible bech32 ID and hex in case of CIP-0129 drepId. Otherwise the data remain unmodified.
  *
- * @throws {Error} If the DRep ID prefix is invalid, an error is thrown.
  */
 export const enhanceDRep = <T extends { drep_id: string; hex: string }>(
   data: T,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,5 @@
 import { validation } from '@blockfrost/blockfrost-utils';
 import { getConfig } from '../config.js';
-import { bech32 } from 'bech32';
 
 type BlockfrostNetwork = 'mainnet' | 'testnet' | 'preview' | 'preprod' | 'sanchonet';
 
@@ -47,46 +46,4 @@ export const isTestnet = (): boolean => {
   const network = getConfig().network;
 
   return network === 'mainnet' ? false : true;
-};
-
-/**
- * Validates a DRep ID and returns both the ID and its raw format if applicable.
- *
- * @param {string} bechDrepId - The DRep ID in Bech32 format that needs to be validated.
- * @returns {{ id: string, raw: string | null }} - An object containing the validated ID and its raw form.
- *   - `id`: The original DRep ID.
- *   - `raw`: The raw format of the DRep ID in hexadecimal if applicable, or `null` for special cases ()drep_always_abstain, drep_always_no_confidence).
- *
- * @throws {Error} If the DRep ID prefix is invalid, an error is thrown.
- */
-export const validateDRepId = (
-  bechDrepId: string,
-): {
-  id: string;
-  raw: string | null;
-  hasScript: boolean;
-} => {
-  const SPECIAL_DREP_IDS = ['drep_always_abstain', 'drep_always_no_confidence'];
-
-  if (SPECIAL_DREP_IDS.includes(bechDrepId)) {
-    return {
-      id: bechDrepId,
-      raw: null,
-      hasScript: false,
-    };
-  }
-  const { prefix, words } = bech32.decode(bechDrepId);
-
-  if (prefix !== 'drep' && prefix !== 'drep_script') {
-    throw new Error('Invalid drep id prefix');
-  }
-
-  const hashBuf = Buffer.from(bech32.fromWords(words));
-  const drepIdRaw = `\\x${Buffer.from(hashBuf).toString('hex')}`;
-
-  return {
-    id: bechDrepId,
-    raw: drepIdRaw,
-    hasScript: prefix === 'drep_script',
-  };
 };

--- a/test/unit/tests/utils/governance.ts
+++ b/test/unit/tests/utils/governance.ts
@@ -1,0 +1,171 @@
+/* cSpell:disable */
+
+import { describe, expect, test } from 'vitest';
+import * as governanceUtils from '../../../../src/utils/governance.js';
+
+describe('governance utils', () => {
+  test('governanceUtils.validateDRepId', () => {
+    expect(governanceUtils.validateDRepId('drep_always_abstain')).toStrictEqual({
+      isCip129: false,
+      dbSync: { id: 'drep_always_abstain', raw: null, hasScript: false },
+      cip129: {
+        id: 'drep_always_abstain',
+        hex: null,
+      },
+    });
+
+    expect(governanceUtils.validateDRepId('drep_always_no_confidence')).toStrictEqual({
+      isCip129: false,
+      dbSync: { id: 'drep_always_no_confidence', raw: null, hasScript: false },
+      cip129: {
+        id: 'drep_always_no_confidence',
+        hex: null,
+      },
+    });
+
+    // Note: in reality this is scriptHash dRep on preprod
+    expect(
+      governanceUtils.validateDRepId('drep1y3wylkrkyt3q6u078ajh8f2henflpsq5hrcqhfa3yfmlqx7z66n'),
+    ).toStrictEqual({
+      isCip129: false,
+      dbSync: {
+        id: 'drep1y3wylkrkyt3q6u078ajh8f2henflpsq5hrcqhfa3yfmlqx7z66n',
+        raw: '\\x245c4fd87622e20d71fe3f6573a557ccd3f0c014b8f00ba7b12277f0',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1ygj9cn7cwc3wyrt3lclk2ua92lxd8uxqzju0qza8ky380uqjnj28h',
+        hex: '22245c4fd87622e20d71fe3f6573a557ccd3f0c014b8f00ba7b12277f0',
+      },
+    });
+
+    // Note: in reality this is scriptHash dRep on preprod
+    expect(
+      governanceUtils.validateDRepId('drep1edu7a90eszdus0hguck2w3lxr5r0juvc9frrxv3d2e6fcnqte0e'),
+    ).toStrictEqual({
+      isCip129: false,
+      dbSync: {
+        id: 'drep1edu7a90eszdus0hguck2w3lxr5r0juvc9frrxv3d2e6fcnqte0e',
+        raw: '\\xcb79ee95f9809bc83ee8e62ca747e61d06f971982a4633322d56749c',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1yt9hnm54lxqfhjp7arnzef68ucwsd7t3nq4yvvej94t8f8qgam3dv',
+        hex: '22cb79ee95f9809bc83ee8e62ca747e61d06f971982a4633322d56749c',
+      },
+    });
+
+    expect(
+      governanceUtils.validateDRepId(
+        'drep_script1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vadhlap',
+      ),
+    ).toStrictEqual({
+      isCip129: false,
+      dbSync: {
+        id: 'drep_script1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vadhlap',
+        raw: '\\xbed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
+        hasScript: true,
+      },
+      cip129: {
+        id: 'drep1ywldpc30gfsuk2ja07dmpdwcknudumcvl6qcgv4hnv60z9sl4umuv',
+        hex: '23bed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
+      },
+    });
+
+    expect(
+      governanceUtils.validateDRepId('drep1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vj02hpq'),
+    ).toStrictEqual({
+      isCip129: false,
+      dbSync: {
+        id: 'drep1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vj02hpq',
+        raw: '\\xbed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1y2ldpc30gfsuk2ja07dmpdwcknudumcvl6qcgv4hnv60z9sl8v2ut',
+        hex: '22bed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
+      },
+    });
+
+    expect(
+      governanceUtils.validateDRepId(
+        'drep_script16pxnn38ykshfahwmkaqmke3kdqaksg4w935d7uztvh8y5sh6f6d',
+      ),
+    ).toStrictEqual({
+      isCip129: false,
+      dbSync: {
+        id: 'drep_script16pxnn38ykshfahwmkaqmke3kdqaksg4w935d7uztvh8y5sh6f6d',
+        raw: '\\xd04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
+        hasScript: true,
+      },
+      cip129: {
+        id: 'drep1y0gy6wwyuj6za8kamwm5rwmxxe5rk6pz4ckx3hmsfdjuujsr70shz',
+        hex: '23d04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
+      },
+    });
+
+    expect(
+      governanceUtils.validateDRepId('drep1y0gy6wwyuj6za8kamwm5rwmxxe5rk6pz4ckx3hmsfdjuujsr70shz'),
+    ).toStrictEqual({
+      isCip129: true,
+      dbSync: {
+        id: 'drep16pxnn38ykshfahwmkaqmke3kdqaksg4w935d7uztvh8y5l48pxv',
+        raw: '\\xd04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
+        hasScript: true,
+      },
+      cip129: {
+        id: 'drep1y0gy6wwyuj6za8kamwm5rwmxxe5rk6pz4ckx3hmsfdjuujsr70shz',
+        hex: '23d04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
+      },
+    });
+
+    // CIP129
+    // test vector
+    expect(
+      governanceUtils.validateDRepId('drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n'),
+    ).toStrictEqual({
+      isCip129: true,
+      dbSync: {
+        id: 'drep1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqua9udh',
+        raw: '\\x00000000000000000000000000000000000000000000000000000000',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n',
+        hex: '2200000000000000000000000000000000000000000000000000000000',
+      },
+    });
+
+    // HOSKY
+    expect(
+      governanceUtils.validateDRepId('drep1yf2jzhuc4f7eu2yay9d9ta3dykxxcwn34wz8kak7nhd7vcgrxn7ns'),
+    ).toStrictEqual({
+      isCip129: true,
+      dbSync: {
+        id: 'drep125s4lx920k0z38fptf2lvtf933kr5udts3ahdh5am0nxzcqwua9',
+        raw: '\\x55215f98aa7d9e289d215a55f62d258c6c3a71ab847b76de9ddbe661',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1yf2jzhuc4f7eu2yay9d9ta3dykxxcwn34wz8kak7nhd7vcgrxn7ns',
+        hex: '2255215f98aa7d9e289d215a55f62d258c6c3a71ab847b76de9ddbe661',
+      },
+    });
+
+    // Sebastien Guillemot セバ
+    expect(
+      governanceUtils.validateDRepId('drep1y2csyxt7u2hl4674pl9cef5lknafaw5nraxvyx033kmd0es3awuv0'),
+    ).toStrictEqual({
+      isCip129: true,
+      dbSync: {
+        id: 'drep1kyppjlhz4lawh4g0ewx2d8a5l20t4yclfnppnuvdkmt7vccg836',
+        raw: '\\xb102197ee2affaebd50fcb8ca69fb4fa9eba931f4cc219f18db6d7e6',
+        hasScript: false,
+      },
+      cip129: {
+        id: 'drep1y2csyxt7u2hl4674pl9cef5lknafaw5nraxvyx033kmd0es3awuv0',
+        hex: '22b102197ee2affaebd50fcb8ca69fb4fa9eba931f4cc219f18db6d7e6',
+      },
+    });
+  });
+});

--- a/test/unit/tests/utils/validation.ts
+++ b/test/unit/tests/utils/validation.ts
@@ -1,3 +1,4 @@
+/* cSpell:disable */
 import { describe, expect, test, vi } from 'vitest';
 import * as config from '../../../../src/config.js';
 import * as validationUtils from '../../../../src/utils/validation.js';
@@ -102,63 +103,6 @@ describe('validation-format-utils', () => {
       const result = validationUtils.validateHex(fixture.input);
 
       expect(result).toStrictEqual(fixture.response);
-    });
-  });
-
-  test('validationUtils.validateDRepId', () => {
-    expect(validationUtils.validateDRepId('drep_always_abstain')).toStrictEqual({
-      id: 'drep_always_abstain',
-      raw: null,
-      hasScript: false,
-    });
-
-    expect(validationUtils.validateDRepId('drep_always_no_confidence')).toStrictEqual({
-      id: 'drep_always_no_confidence',
-      raw: null,
-      hasScript: false,
-    });
-
-    expect(
-      validationUtils.validateDRepId('drep1y3wylkrkyt3q6u078ajh8f2henflpsq5hrcqhfa3yfmlqx7z66n'),
-    ).toStrictEqual({
-      id: 'drep1y3wylkrkyt3q6u078ajh8f2henflpsq5hrcqhfa3yfmlqx7z66n',
-      raw: '\\x245c4fd87622e20d71fe3f6573a557ccd3f0c014b8f00ba7b12277f0',
-      hasScript: false,
-    });
-
-    expect(
-      validationUtils.validateDRepId('drep1edu7a90eszdus0hguck2w3lxr5r0juvc9frrxv3d2e6fcnqte0e'),
-    ).toStrictEqual({
-      id: 'drep1edu7a90eszdus0hguck2w3lxr5r0juvc9frrxv3d2e6fcnqte0e',
-      raw: '\\xcb79ee95f9809bc83ee8e62ca747e61d06f971982a4633322d56749c',
-      hasScript: false,
-    });
-
-    expect(
-      validationUtils.validateDRepId(
-        'drep_script1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vadhlap',
-      ),
-    ).toStrictEqual({
-      id: 'drep_script1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vadhlap',
-      raw: '\\xbed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
-      hasScript: true,
-    });
-
-    expect(
-      validationUtils.validateDRepId('drep1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vj02hpq'),
-    ).toStrictEqual({
-      id: 'drep1hmgwyt6zv89j5htlnwcttk95lr0x7r87sxzr9dumxnc3vj02hpq',
-      raw: '\\xbed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
-      hasScript: false,
-    });
-    expect(
-      validationUtils.validateDRepId(
-        'drep_script16pxnn38ykshfahwmkaqmke3kdqaksg4w935d7uztvh8y5sh6f6d',
-      ),
-    ).toStrictEqual({
-      id: 'drep_script16pxnn38ykshfahwmkaqmke3kdqaksg4w935d7uztvh8y5sh6f6d',
-      raw: '\\xd04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
-      hasScript: true,
     });
   });
 });

--- a/yarn-project.nix
+++ b/yarn-project.nix
@@ -119,7 +119,6 @@ let
   });
 
 cacheEntries = {
-"@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0" = { filename = "@emurgo-cardano-serialization-lib-nodejs-npm-11.5.0-8c2e047031-f9e271704e.zip"; sha512 = "f9e271704ef12eb018bc0a15b8c6f83c61db694a422674267be6c546a9a89dd8b200781aca3f97dd5bb4291b0c84f6c60177fcf7e550964188a4ed6a8efd0316"; };
 "@types/blake2b@npm:2.1.3" = { filename = "@types-blake2b-npm-2.1.3-62a57db1c9-55a6ed7123.zip"; sha512 = "55a6ed7123a7adc82cc51131644b6c035c28142d028fbc23fe06251c76583ee3303d73204e21de8ea075ef84a04c4ed424754f5035fed20730a85272620a0de3"; };
 "@types/config@npm:3.3.1" = { filename = "@types-config-npm-3.3.1-2b50dd112c-dc6604a6bb.zip"; sha512 = "dc6604a6bb90179ea7fbe5a3de23301999dd5b115f9999f9e48db412b7c86224919bd9af8915e7ed8734bd5f729fcbcc0eb5adf37fe2422bccd98deae1063530"; };
 "@types/node@npm:20.6.2" = { filename = "@types-node-npm-20.6.2-bff5d8378f-96fe530387.zip"; sha512 = "96fe5303872640a173f3fd43e289a451776ed5b8f0090094447c6790b43f23fb607eea8268af0829cef4d132e5afa0bfa4cd871aa7412e9042a414a698e9e971"; };
@@ -197,6 +196,7 @@ cacheEntries = {
 "glob@npm:10.3.4" = { filename = "glob-npm-10.3.4-f58cd31f55-176b97c124.zip"; sha512 = "176b97c124414401cb51329a93d2ba112cef8814adbed10348481916b9521b677773eee2691cb6b24d66632d8c8bb8913533f5ac4bfb2d0ef5454a1856082361"; };
 "diff@npm:5.1.0" = { filename = "diff-npm-5.1.0-d24d222280-c7bf0df7c9.zip"; sha512 = "c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90"; };
 "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=f3b441" = { filename = "typescript-patch-79249ecb34-2373c693f3.zip"; sha512 = "2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba"; };
+"@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0" = { filename = "@emurgo-cardano-serialization-lib-nodejs-npm-11.5.0-8c2e047031-f9e271704e.zip"; sha512 = "f9e271704ef12eb018bc0a15b8c6f83c61db694a422674267be6c546a9a89dd8b200781aca3f97dd5bb4291b0c84f6c60177fcf7e550964188a4ed6a8efd0316"; };
 "bottleneck@npm:2.19.5" = { filename = "bottleneck-npm-2.19.5-2c6092aa17-c5eef1bbea.zip"; sha512 = "c5eef1bbea12cef1f1405e7306e7d24860568b0f7ac5eeab706a86762b3fc65ef6d1c641c8a166e4db90f412fc5c948fc5ce8008a8cd3d28c7212ef9c3482bda"; };
 "@emurgo/cardano-serialization-lib-nodejs@npm:11.4.0" = { filename = "@emurgo-cardano-serialization-lib-nodejs-npm-11.4.0-98e9c716e3-2033f63352.zip"; sha512 = "2033f633521283026f9e418613eb1840d44705119826f615c14b9a6adba995e8d66f5678fc5bb752cf2695db937c67d395795c533fe46ded2f7ca0e8973a45eb"; };
 "yaml@npm:2.3.1" = { filename = "yaml-npm-2.3.1-743f5688d1-2c7bc9a7cd.zip"; sha512 = "2c7bc9a7cd4c9f40d3b0b0a98e370781b68b8b7c4515720869aced2b00d92f5da1762b4ffa947f9e795d6cd6b19f410bd4d15fdd38aca7bd96df59bd9486fb54"; };

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,17 +152,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0, @emurgo/cardano-serialization-lib-nodejs@npm:^11.5.0":
-  version: 11.5.0
-  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0"
-  checksum: f9e271704ef12eb018bc0a15b8c6f83c61db694a422674267be6c546a9a89dd8b200781aca3f97dd5bb4291b0c84f6c60177fcf7e550964188a4ed6a8efd0316
-  languageName: node
-  linkType: hard
-
 "@emurgo/cardano-serialization-lib-nodejs@npm:^11.4.0":
   version: 11.4.0
   resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.4.0"
   checksum: 2033f633521283026f9e418613eb1840d44705119826f615c14b9a6adba995e8d66f5678fc5bb752cf2695db937c67d395795c533fe46ded2f7ca0e8973a45eb
+  languageName: node
+  linkType: hard
+
+"@emurgo/cardano-serialization-lib-nodejs@npm:^11.5.0":
+  version: 11.5.0
+  resolution: "@emurgo/cardano-serialization-lib-nodejs@npm:11.5.0"
+  checksum: f9e271704ef12eb018bc0a15b8c6f83c61db694a422674267be6c546a9a89dd8b200781aca3f97dd5bb4291b0c84f6c60177fcf7e550964188a4ed6a8efd0316
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,6 @@ __metadata:
     "@blockfrost/blockfrost-js": 5.5.0
     "@blockfrost/blockfrost-utils": 2.8.1
     "@blockfrost/openapi": 0.1.69
-    "@emurgo/cardano-serialization-lib-nodejs": 11.5.0
     "@fastify/cors": ^9.0.1
     "@fastify/http-proxy": ^9.5.0
     "@fastify/postgres": ^5.2.2


### PR DESCRIPTION
### Added

- Support for CIP129 DRep ID - you can query DReps using both legacy format and CIP129 format. The `drep_id` and `hex` fields will reflect the format of the query param

### Changed

- BREAKING CHANGE: Endpoints `/governance/dreps` and `/governance/proposals/{tx_hash}/{cert_index}/votes` are now using CIP129 format
