### PR TITLE
Fix SQL queries: Add missing field to GROUP BY to resolve error

### DIFF
--- a/src/sql/accounts/accounts_stake_address_addresses_total.sql
+++ b/src/sql/accounts/accounts_stake_address_addresses_total.sql
@@ -11,7 +11,7 @@ WITH queried_outputs AS (
     JOIN stake_address sa ON (txo.stake_address_id = sa.id)
     LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
   WHERE sa.view = $1
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 ),
 queried_inputs AS (
   SELECT COALESCE(txo.value, 0) AS "amount",
@@ -22,7 +22,7 @@ queried_inputs AS (
     JOIN stake_address sa ON (txo.stake_address_id = sa.id)
     LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
   WHERE sa.view = $1
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 )
 SELECT (
     SELECT sa.view

--- a/src/sql/addresses/addresses_address.sql
+++ b/src/sql/addresses/addresses_address.sql
@@ -24,7 +24,7 @@ WITH queried_address AS (
       END
     )
     AND tx.valid_contract = 'true' -- don't count utxos that are part of transaction that failed script validation at stage 2
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 )
 SELECT (
     SELECT CASE

--- a/src/sql/addresses/addresses_address_extended.sql
+++ b/src/sql/addresses/addresses_address_extended.sql
@@ -24,7 +24,7 @@ WITH queried_address AS (
       END
     ) -- don't count utxos that are part of transaction that failed script validation at stage 2
     AND tx.valid_contract = 'true'
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 )
 SELECT (
     SELECT CASE

--- a/src/sql/addresses/addresses_address_total.sql
+++ b/src/sql/addresses/addresses_address_total.sql
@@ -15,7 +15,7 @@ WITH queried_outputs AS (
         ELSE txo.address = $1
       END
     )
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 ),
 queried_inputs AS (
   SELECT COALESCE(txo.value, 0) AS "amount",
@@ -30,7 +30,7 @@ queried_inputs AS (
         ELSE txo.address = $1
       END
     )
-  GROUP BY txo.id
+  GROUP BY txo.id, txo.value
 )
 SELECT (
     SELECT CASE


### PR DESCRIPTION
### Issue:
Certain routes would not function properly due to an SQL aggregation error.

### Cause of Issue:
A missing field in the `GROUP BY` clause resulted in an error.

### Error Message:
`SQL Error [42803]: ERROR: column "txo.value" must appear in the GROUP BY clause or be used in an aggregate function`

### Fix:
Added `txo.value` to the affected `GROUP BY` clauses to ensure proper grouping and resolve the error.

### Affected Routes:
- `/accounts/{stake_address}/addresses/total`
- `/addresses/{address}`
- `/addresses/{address}/total`
- `/addresses/{address}/extended`

### Validation:
Results have been validated against official Blockfrost endpoints after the fixes were applied.