### PR TITLE
fix: handle CIP-0129 minimal encoding of gov_action_id with cert_index 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.3] - 2026-04-28
+
+### Fixed
+
+- Fixed `/governance/proposals/:gov_action_id` returning a 500 error for `gov_action_id`s that use the minimal CIP-0129 encoding for `cert_index = 0` (32-byte payload, no trailing index byte)
+
 ## [6.4.2] - 2026-04-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockfrost-backend-ryo",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "description": "",
   "keywords": [],
   "license": "Apache-2.0",

--- a/src/utils/governance.ts
+++ b/src/utils/governance.ts
@@ -241,7 +241,7 @@ export const validateGovActionId = (govActionId: string) => {
 
   const txHash = hexBuf.subarray(0, 32).toString('hex');
   const certIndexHex = hexBuf.subarray(32).toString('hex');
-  const certIndex = Number.parseInt(certIndexHex, 16);
+  const certIndex = certIndexHex === '' ? 0 : Number.parseInt(certIndexHex, 16);
 
   return {
     tx_hash: txHash,

--- a/test/unit/tests/utils/governance.ts
+++ b/test/unit/tests/utils/governance.ts
@@ -292,6 +292,16 @@ describe('governance utils', () => {
       tx_hash: '55596ded33edf2083c152026708c648140e5f33a7cb47c4e6312864146f4ff56',
       cert_index: 0,
     });
+
+    // Same tx_hash, non-minimal 33-byte encoding (trailing 0x00 suffix) — must parse identically.
+    expect(
+      governanceUtils.validateGovActionId(
+        'gov_action124vkmmfnaheqs0q4yqn8prrys9qwtue60j68cnnrz2ryz3h5latqquux28u',
+      ),
+    ).toStrictEqual({
+      tx_hash: '55596ded33edf2083c152026708c648140e5f33a7cb47c4e6312864146f4ff56',
+      cert_index: 0,
+    });
   });
 
   test('governanceUtils.getGovActionId', () => {

--- a/test/unit/tests/utils/governance.ts
+++ b/test/unit/tests/utils/governance.ts
@@ -282,6 +282,16 @@ describe('governance utils', () => {
       tx_hash: '15f82a365bdee483a4b03873a40d3829cc88c048ff3703e11bd01dd9e035c916',
       cert_index: 0,
     });
+
+    // CIP-0129 minimal encoding: cert_index 0 omits the suffix byte entirely (32-byte payload).
+    expect(
+      governanceUtils.validateGovActionId(
+        'gov_action124vkmmfnaheqs0q4yqn8prrys9qwtue60j68cnnrz2ryz3h5latqgzgzxc',
+      ),
+    ).toStrictEqual({
+      tx_hash: '55596ded33edf2083c152026708c648140e5f33a7cb47c4e6312864146f4ff56',
+      cert_index: 0,
+    });
   });
 
   test('governanceUtils.getGovActionId', () => {


### PR DESCRIPTION
## Summary

- Fix a 500 (`22P02 invalid input syntax for type bigint: \"NaN\"`) on `/governance/proposals/:gov_action_id` when the id uses the minimal CIP-0129 encoding for `cert_index = 0` (32-byte payload — `tx_hash` only, no trailing index byte). Previously `parseInt('', 16)` returned `NaN`, which was then forwarded to Postgres as the `cert_index` parameter.
- Add regression tests covering both encodings of the same proposal (32-byte minimal and 33-byte trailing `0x00`).
- Bump to `6.4.3` and update CHANGELOG.

Repro: `GET /governance/proposals/gov_action124vkmmfnaheqs0q4yqn8prrys9qwtue60j68cnnrz2ryz3h5latqgzgzxc`

## Test plan

- [x] `yarn test` — `validateGovActionId` unit tests pass, including the new minimal- and non-minimal-encoding cases
- [ ] Hit the affected endpoint on a node with the offending proposal and confirm 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)