### PR TITLE
build the flake on runner1, so its pre-built for dev

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,12 @@
+name: Build tag
+
+on:
+  push:
+    tags:
+      - build
+jobs:
+  flake:
+    name: nix flake build
+    runs-on: [self-hosted, Linux, X64, nixos]
+    steps:
+      - run: nix build github:blockfrost/blockfrost-backend-ryo/$GITHUB_SHA#default


### PR DESCRIPTION
this should cache the nix builds on runner1 and prevent dev from falling over every time `build` is pushed to