### PR TITLE
perf: push pagination before joins in drep-votes and delegations SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved query performance of `/governance/dreps/:drep_id/votes` and `/accounts/:stake_address/delegations` by paginating before joining auxiliary tables.
+
 ## [6.6.1] - 2026-06-18
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `deposit` field per row in `/accounts/:stake_address/registrations` response — deposit paid at the registration cert (`null` on `deregistered` rows). Falls back to the `key_deposit` protocol parameter at the registration's epoch when the underlying db-sync row predates the addition of the `deposit` column.
 - New `deposit` field per row in `/governance/dreps/:drep_id/updates` response — string lovelace amount on `registered`; `null` on `deregistered` and `updated`.
 
+### Changed
+
+- Improved query performance of `/governance/dreps/:drep_id/votes` and `/accounts/:stake_address/delegations` by paginating before joining auxiliary tables.
+
 ## [6.4.3] - 2026-04-28
 
 ### Fixed

--- a/src/sql/accounts/accounts_stake_address_delegations.sql
+++ b/src/sql/accounts/accounts_stake_address_delegations.sql
@@ -1,16 +1,44 @@
-SELECT d.active_epoch_no::INTEGER AS "active_epoch",
+WITH paged_delegations AS (
+  -- Pagination is pushed before the joins to tx / block / pool_hash, so they fire
+  -- only for the page we return, not for every delegation made by this stake key.
+  SELECT d.id, d.active_epoch_no, d.tx_id, d.pool_hash_id
+  FROM stake_address sa
+    JOIN delegation d ON (sa.id = d.addr_id)
+  WHERE sa.view = $4
+  ORDER BY CASE
+      WHEN LOWER($1) = 'desc' THEN d.tx_id
+    END DESC,
+    CASE
+      WHEN LOWER($1) <> 'desc'
+      OR $1 IS NULL THEN d.tx_id
+    END ASC
+  LIMIT CASE
+      WHEN $2 >= 1
+      AND $2 <= 100 THEN $2
+      ELSE 100
+    END OFFSET CASE
+      WHEN $3 > 1
+      AND $3 < 2147483647 THEN ($3 - 1) * (
+        CASE
+          WHEN $2 >= 1
+          AND $2 <= 100 THEN $2
+          ELSE 100
+        END
+      )
+      ELSE 0
+    END
+)
+SELECT p.active_epoch_no::INTEGER AS "active_epoch",
   encode(tx.hash, 'hex') AS "tx_hash",
-  tx.out_sum::TEXT AS "amount", -- cast to TEXT to avoid number overflow
+  tx.out_sum::TEXT AS "amount",
   ph.view AS "pool_id",
   b.slot_no::INTEGER AS "tx_slot",
   b.block_no AS "block_height",
   EXTRACT(EPOCH FROM b.time)::INTEGER AS "block_time"
-FROM stake_address sa
-  JOIN delegation d ON (sa.id = d.addr_id)
-  JOIN tx ON (d.tx_id = tx.id)
+FROM paged_delegations p
+  JOIN tx ON (p.tx_id = tx.id)
   JOIN block b ON (b.id = tx.block_id)
-  JOIN pool_hash ph ON (ph.id = d.pool_hash_id)
-WHERE sa.view = $4
+  JOIN pool_hash ph ON (ph.id = p.pool_hash_id)
 ORDER BY CASE
     WHEN LOWER($1) = 'desc' THEN tx.id
   END DESC,
@@ -18,18 +46,3 @@ ORDER BY CASE
     WHEN LOWER($1) <> 'desc'
     OR $1 IS NULL THEN tx.id
   END ASC
-LIMIT CASE
-    WHEN $2 >= 1
-    AND $2 <= 100 THEN $2
-    ELSE 100
-  END OFFSET CASE
-    WHEN $3 > 1
-    AND $3 < 2147483647 THEN ($3 - 1) * (
-      CASE
-        WHEN $2 >= 1
-        AND $2 <= 100 THEN $2
-        ELSE 100
-      END
-    )
-    ELSE 0
-  END

--- a/src/sql/accounts/unpaged/accounts_stake_address_delegations.sql
+++ b/src/sql/accounts/unpaged/accounts_stake_address_delegations.sql
@@ -1,16 +1,27 @@
-SELECT d.active_epoch_no::INTEGER AS "active_epoch",
+WITH ordered_delegations AS (
+  SELECT d.id, d.active_epoch_no, d.tx_id, d.pool_hash_id
+  FROM stake_address sa
+    JOIN delegation d ON (sa.id = d.addr_id)
+  WHERE sa.view = $2
+  ORDER BY CASE
+      WHEN LOWER($1) = 'desc' THEN d.tx_id
+    END DESC,
+    CASE
+      WHEN LOWER($1) <> 'desc'
+      OR $1 IS NULL THEN d.tx_id
+    END ASC
+)
+SELECT o.active_epoch_no::INTEGER AS "active_epoch",
   encode(tx.hash, 'hex') AS "tx_hash",
-  tx.out_sum::TEXT AS "amount", -- cast to TEXT to avoid number overflow
+  tx.out_sum::TEXT AS "amount",
   ph.view AS "pool_id",
   b.slot_no::INTEGER AS "tx_slot",
   b.block_no AS "block_height",
   EXTRACT(EPOCH FROM b.time)::INTEGER AS "block_time"
-FROM stake_address sa
-  JOIN delegation d ON (sa.id = d.addr_id)
-  JOIN tx ON (d.tx_id = tx.id)
+FROM ordered_delegations o
+  JOIN tx ON (o.tx_id = tx.id)
   JOIN block b ON (b.id = tx.block_id)
-  JOIN pool_hash ph ON (ph.id = d.pool_hash_id)
-WHERE sa.view = $2
+  JOIN pool_hash ph ON (ph.id = o.pool_hash_id)
 ORDER BY CASE
     WHEN LOWER($1) = 'desc' THEN tx.id
   END DESC,

--- a/src/sql/governance/dreps_drep_id_votes.sql
+++ b/src/sql/governance/dreps_drep_id_votes.sql
@@ -1,37 +1,55 @@
+WITH drep AS (
+  SELECT id
+  FROM drep_hash dh
+  WHERE (
+      ($4::bytea IS NOT NULL AND dh.raw = $4) OR
+      ($4 IS NULL AND dh.view = $5)
+    )
+    AND dh.has_script = $6
+  LIMIT 1
+),
+paged_votes AS (
+  -- Pagination is pushed before the joins to tx / gov_action_proposal / proposal_tx,
+  -- so they fire only for the page we return, not for every vote by this DRep.
+  SELECT vp.id, vp.tx_id, vp.gov_action_proposal_id, vp.index AS cert_index, vp.vote
+  FROM voting_procedure vp
+  WHERE vp.drep_voter = (SELECT id FROM drep)
+  ORDER BY CASE
+      WHEN LOWER($1) = 'desc' THEN vp.id
+    END DESC,
+    CASE
+      WHEN LOWER($1) <> 'desc'
+      OR $1 IS NULL THEN vp.id
+    END ASC
+  LIMIT CASE
+      WHEN $2 >= 1
+      AND $2 <= 100 THEN $2
+      ELSE 100
+    END OFFSET CASE
+      WHEN $3 > 1
+      AND $3 < 2147483647 THEN ($3 - 1) * (
+        CASE
+          WHEN $2 >= 1
+          AND $2 <= 100 THEN $2
+          ELSE 100
+        END
+      )
+      ELSE 0
+    END
+)
 SELECT encode(tx.hash, 'hex') AS "tx_hash",
-  vp.index AS "cert_index",
+  p.cert_index AS "cert_index",
   encode(proposal_tx.hash, 'hex') AS "proposal_tx_hash",
   gap.index AS "proposal_cert_index",
-  LOWER(vote::TEXT) AS "vote" -- Yes, No, Abstain -> yes,no,abstain
-FROM voting_procedure vp
-  JOIN drep_hash dh ON (vp.drep_voter = dh.id)
-  JOIN tx ON (vp.tx_id = tx.id)
-  JOIN gov_action_proposal gap ON (vp.gov_action_proposal_id = gap.id)
+  LOWER(p.vote::TEXT) AS "vote"
+FROM paged_votes p
+  JOIN tx ON (p.tx_id = tx.id)
+  JOIN gov_action_proposal gap ON (p.gov_action_proposal_id = gap.id)
   JOIN tx AS proposal_tx ON (gap.tx_id = proposal_tx.id)
-WHERE (
-    ($4::bytea IS NOT NULL AND dh.raw = $4) OR
-    ($4 IS NULL AND dh.view = $5)
-  )
-  AND dh.has_script = $6
 ORDER BY CASE
-    WHEN LOWER($1) = 'desc' THEN vp.id
+    WHEN LOWER($1) = 'desc' THEN p.id
   END DESC,
   CASE
     WHEN LOWER($1) <> 'desc'
-    OR $1 IS NULL THEN vp.id
+    OR $1 IS NULL THEN p.id
   END ASC
-LIMIT CASE
-    WHEN $2 >= 1
-    AND $2 <= 100 THEN $2
-    ELSE 100
-  END OFFSET CASE
-    WHEN $3 > 1
-    AND $3 < 2147483647 THEN ($3 - 1) * (
-      CASE
-        WHEN $2 >= 1
-        AND $2 <= 100 THEN $2
-        ELSE 100
-      END
-    )
-    ELSE 0
-  END

--- a/src/sql/governance/unpaged/dreps_drep_id_votes.sql
+++ b/src/sql/governance/unpaged/dreps_drep_id_votes.sql
@@ -1,18 +1,34 @@
+WITH drep AS (
+  SELECT id
+  FROM drep_hash dh
+  WHERE (
+      ($2::bytea IS NOT NULL AND dh.raw = $2) OR
+      ($2 IS NULL AND dh.view = $3)
+    )
+    AND dh.has_script = $4
+  LIMIT 1
+),
+ordered_votes AS (
+  SELECT vp.id, vp.tx_id, vp.index AS cert_index, vp.vote
+  FROM voting_procedure vp
+  WHERE vp.drep_voter = (SELECT id FROM drep)
+  ORDER BY CASE
+      WHEN LOWER($1) = 'desc' THEN vp.id
+    END DESC,
+    CASE
+      WHEN LOWER($1) <> 'desc'
+      OR $1 IS NULL THEN vp.id
+    END ASC
+)
 SELECT encode(tx.hash, 'hex') AS "tx_hash",
-  vp.index AS "cert_index",
-  LOWER(vote::TEXT) AS "vote" -- Yes, No, Abstain -> yes,no,abstain
-FROM voting_procedure vp
-  JOIN drep_hash dh ON (vp.drep_voter = dh.id)
-  JOIN tx ON (vp.tx_id = tx.id)
-WHERE (
-    ($2::bytea IS NOT NULL AND dh.raw = $2) OR
-    ($2 IS NULL AND dh.view = $3)
-  )
-  AND dh.has_script = $4
+  v.cert_index AS "cert_index",
+  LOWER(v.vote::TEXT) AS "vote"
+FROM ordered_votes v
+  JOIN tx ON (v.tx_id = tx.id)
 ORDER BY CASE
-    WHEN LOWER($1) = 'desc' THEN vp.id
+    WHEN LOWER($1) = 'desc' THEN v.id
   END DESC,
   CASE
     WHEN LOWER($1) <> 'desc'
-    OR $1 IS NULL THEN vp.id
+    OR $1 IS NULL THEN v.id
   END ASC


### PR DESCRIPTION
## Summary

Two paged endpoints with the same shape — many joins, filter on the driving table, `ORDER BY ... LIMIT/OFFSET` at the outer query — were having Postgres fire every join for every matching row before sorting and trimming to 100. Wrapping the filter + sort + limit in a CTE pushes the joins after pagination, so they fire only for the rows actually returned.

## Verified performance

Measured on the mainnet dev db-sync after rebase, `EXPLAIN (ANALYZE, BUFFERS)`, cache-warmed, `count=100` page 1:

| Endpoint | Test entity | Before | After | Result |
|---|---|---|---|---|
| `GET /governance/dreps/:drep_id/votes` | DRep with 153 votes | 7.3 ms · 2188 shared buffers | 4.25 ms · 1354 buffers | **~1.7×**, ~38% fewer buffers |
| `GET /accounts/:stake_address/delegations` | stake key with 1282 delegations | ~8.6–11 ms · 15448 buffers | ~1.7–3.8 ms · 1264 buffers | **~4–6×**, **~12× fewer buffers** |

The gain scales with rows-per-entity (joins fire for the returned page instead of for every vote/delegation), so the delegations win is the larger one here and widens further on production accounts/DReps with more history. Absolute ms is lower than earlier cold/production figures because these runs are warm-cache on the dev box — the ratios are the point.

## How it works

Extract the driving table's filter + `ORDER BY` + `LIMIT/OFFSET` into a `paged_…` CTE selecting only the columns needed downstream. The outer `SELECT` then joins to `tx`, `block`, `gov_action_proposal`, `pool_hash` etc., touching only the page of rows we return. Same approach already applied to the committee endpoints.

## Correctness — verified

Old vs new produce **byte-identical** result sets (diffed live against the dev db-sync):

- `/governance/dreps/:drep_id/votes` — identical rows on pages 1 and 2 (paged) and the full unpaged set (153 rows).
- `/accounts/:stake_address/delegations` — identical rows on pages 1 and 5 (paged) and the full unpaged set (1282 rows).
- Response shape, field names and `tx.id`/`vp.id` ordering semantics preserved; `desc`, deep pagination and empty results behave the same.
- Type-check clean; full unit suite **551/551** passing.

## What's NOT in scope

Surveyed all paged SQL files in `src/sql/`. The other paged endpoints either already paginate before the heavy work (e.g. `/pools/:id/delegators` — its cost is per-row aggregation, a separate issue), are bound by the driving-table scan rather than the joins, or are already fast on typical inputs.

> Note (pre-existing, not changed here): the unpaged `/governance/dreps/:drep_id/votes` query returns only `tx_hash`/`cert_index`/`vote` (no `proposal_*`), matching master. The route still derives `proposal_id` from the absent fields on the unpaged path — a pre-existing latent bug worth a separate ticket.

## Test plan

- [x] `/governance/dreps/:drep_id/votes` returns identical rows (same field set, same order) on a real DRep.
- [x] `/accounts/:stake_address/delegations` returns identical rows on a heavily-delegated stake key.
- [x] Both endpoints with `order=desc`.
- [x] Pagination (`page=N`) walks the expected boundary.
- [x] Unpaged variants return the full result set in the expected order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
