### PR TITLE
perf: index off_chain_vote_fetch_error (voting_anchor_id, id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Optimized `/governance/proposals/:gov_action_id/metadata` and `/governance/dreps/:drep_id/metadata` queries. Requires new index: `bf_idx_off_chain_vote_fetch_error_anchor` (see README)
+
 ## [6.5.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ CREATE INDEX IF NOT EXISTS bf_idx_tx_id_covering ON public.tx (id) INCLUDE (bloc
 CREATE INDEX IF NOT EXISTS bf_idx_tx_out_sa_paycred_script_id
 ON tx_out (stake_address_id, payment_cred, address_has_script, id);
 CREATE INDEX IF NOT EXISTS bf_idx_voting_procedure_gov_action_proposal_id ON voting_procedure (gov_action_proposal_id);
+CREATE INDEX IF NOT EXISTS bf_idx_off_chain_vote_fetch_error_anchor ON off_chain_vote_fetch_error (voting_anchor_id, id);
 ```
 
 ### Experimental features


### PR DESCRIPTION
## Summary

Adds a btree index on `off_chain_vote_fetch_error (voting_anchor_id, id)`. Cuts buffer/memory footprint of the metadata endpoints, eliminates a Sort step, and forecloses a pathological PK-backward plan that the planner picks on larger DBs.

## Background

`/governance/proposals/:gov_action_id/metadata` and `/governance/dreps/:drep_id/metadata` LATERAL-join a `LIMIT 1` lookup of the latest fetch_error per anchor:

```sql
LEFT JOIN LATERAL (
  SELECT fetch_error
  FROM off_chain_vote_fetch_error
  WHERE voting_anchor_id = va.id
  ORDER BY id DESC
  LIMIT 1
) AS ocvfe ON TRUE
```

The two existing indexes on `off_chain_vote_fetch_error` are PK on `(id)` and unique on `(voting_anchor_id, retry_count)`. Neither supports `WHERE voting_anchor_id = X ORDER BY id DESC LIMIT 1` in a single step. The planner has two suboptimal strategies to pick from:

1. **Index on `(voting_anchor_id, retry_count)` + Sort by id** — fine when matches are few, wasteful when many.
2. **`Index Scan Backward` on the PK + filter on `voting_anchor_id`** — fine when matches sit near the top of the id range, catastrophic when matches are sparse, ancient, or zero (walks the whole table to prove a negative).

The new `(voting_anchor_id, id)` index satisfies both predicates and the ORDER BY id DESC LIMIT 1 from a single index seek, no Sort step.

## Measured impact

### On a ~172 k-row table (typical mainnet today)

The planner already picks the "OK" plan (option 1 above) here, so the absolute wall-clock win is small:

| Metric | BEFORE | AFTER |
|---|---|---|
| Execution Time | 1.98 ms | **0.52 ms** (~3.8×) |
| Total Buffers (shared hit + read) | 51 | 22 (**~57% less**) |
| LATERAL subtree Buffers | 6 | 3 |
| Sort step | quicksort, 25 KB | gone |

### On a ~1.19 M-row table (larger chain snapshot)

The planner here flips to option 2 — `Index Scan Backward` on the PK with `voting_anchor_id` as a row filter. For a proposal whose anchor has **zero** fetch_errors:

```
->  Index Scan Backward using off_chain_vote_fetch_error_pkey
      Filter: (voting_anchor_id = va.id)
      Rows Removed by Filter: 1190072
      Buffers: shared hit=68323
      actual time=184.556..184.556 rows=0 loops=1
```

That's ~547 MB of shared-buffer pages walked per request to prove a negative. The wall-clock (~187 ms) is bad but not catastrophic on its own; the **cache and memory bandwidth cost** is what makes it a real operational hazard:

- Each request evicts ~547 MB of hot pages, slowing unrelated endpoints under concurrent load.
- CPU + memory bandwidth burned on pointless work.
- Buffer-pin contention scales badly at high concurrency.

With the new index, the LATERAL drops to ~3 buffer hits — roughly **22 000×** less buffer churn per query, regardless of how big the table grows.

## Fix

```sql
CREATE INDEX IF NOT EXISTS bf_idx_off_chain_vote_fetch_error_anchor
  ON off_chain_vote_fetch_error (voting_anchor_id, id);
```

Index size: ~5.3 MB on the 172 k-row table (existing PK is 3.3 MB, existing unique is 6.4 MB — new one falls in the same class).

## Changes

- `README.md`: append the index to the existing recommended-indexes block.
- `CHANGELOG.md`: one-line "Changed" entry referencing the new required index, same wording as past index additions (`bf_idx_voting_procedure_gov_action_proposal_id` in 6.4.2).

No code changes — the existing SQL automatically picks up the new index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)