### PR TITLE
fix: stable ordering for /epochs/:number/stakes across db-sync replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optimized `/governance/proposals/:gov_action_id/metadata` and `/governance/dreps/:drep_id/metadata` queries. Requires new index: `bf_idx_off_chain_vote_fetch_error_anchor` (see README)
 
+### Fixed
+
+- `/epochs/:number/stakes` and `/epochs/:number/stakes/:pool_id` returned a different page-1 across db-sync replicas because pagination was keyed on `epoch_stake.id` (an insertion-order auto-increment). Ordering now uses the chain-derived earliest `slot_no` at which each delegator started delegating to their current pool — stable across replicas regardless of db-sync's row-insertion order. Veteran delegators stay at the top regardless of re-delegation churn.
+
 ## [6.5.0] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Optimized `/governance/proposals/:gov_action_id/metadata` and `/governance/dreps/:drep_id/metadata` queries. Requires new index: `bf_idx_off_chain_vote_fetch_error_anchor` (see README)
+- Optimized `/epochs/:number/stakes/:pool_id` query. Recommended new index: `bf_idx_epoch_stake_pool_id_epoch_no` (see README)
 
 ### Fixed
 
-- `/epochs/:number/stakes` and `/epochs/:number/stakes/:pool_id` returned a different page-1 across db-sync replicas because pagination was keyed on `epoch_stake.id` (an insertion-order auto-increment). Ordering now uses the chain-derived earliest `slot_no` at which each delegator started delegating to their current pool — stable across replicas regardless of db-sync's row-insertion order. Veteran delegators stay at the top regardless of re-delegation churn.
+- `/epochs/:number/stakes` and `/epochs/:number/stakes/:pool_id` returned a different page-1 across db-sync replicas because pagination was keyed on `epoch_stake.id` (an insertion-order auto-increment). Ordering is now keyed on the chain-derived `stake_address.hash_raw` — stable across replicas regardless of db-sync's row-insertion order. Deep pages of `/epochs/:number/stakes` degrade to an O(offset) scan with this ordering; creating the optional `bf_tbl_epoch_stake_anchor` table and enabling `dbSync.epochStakeAnchors` (see README) restores fast pagination at any depth.
 
 ## [6.5.0] - 2026-05-15
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,75 @@ CREATE INDEX IF NOT EXISTS bf_idx_tx_out_sa_paycred_script_id
 ON tx_out (stake_address_id, payment_cred, address_has_script, id);
 CREATE INDEX IF NOT EXISTS bf_idx_voting_procedure_gov_action_proposal_id ON voting_procedure (gov_action_proposal_id);
 CREATE INDEX IF NOT EXISTS bf_idx_off_chain_vote_fetch_error_anchor ON off_chain_vote_fetch_error (voting_anchor_id, id);
+CREATE INDEX IF NOT EXISTS bf_idx_epoch_stake_pool_id_epoch_no ON epoch_stake (pool_id, epoch_no);
+```
+
+#### Epoch stake pagination anchors (optional)
+
+`/epochs/{number}/stakes` orders results by the chain-derived `stake_address.hash_raw`, so the
+ordering is stable across db-sync instances out of the box. Because the sort key lives on
+`stake_address`, requesting deep pages (high `page` values) degrades to an O(offset) scan and can
+take seconds for pages deep into a mainnet epoch (~1.3M delegators).
+
+Optionally, you can create the following table and trigger in the db-sync database. It stores
+`hash_raw` at every 1000th position of each epoch's stake snapshot, letting the backend jump
+directly to the requested page (any page is then served in tens of milliseconds). The backfill
+takes roughly 2–3 seconds per mainnet epoch (~25 minutes for the full history); afterwards the
+trigger maintains new epochs as db-sync finishes each epoch's stake snapshot.
+
+To use it, enable the feature in the config file (or via the ENV var
+`BLOCKFROST_CONFIG_DBSYNC_EPOCH_STAKE_ANCHORS=true`):
+
+```yaml
+dbSync:
+  epochStakeAnchors: true
+```
+
+The server refuses to start if the option is enabled but the table is missing.
+
+```sql
+CREATE TABLE IF NOT EXISTS bf_tbl_epoch_stake_anchor (
+  epoch_no BIGINT NOT NULL,
+  rank BIGINT NOT NULL, -- 0-based position within the epoch in hash_raw order
+  hash_raw BYTEA NOT NULL, -- stake_address.hash_raw at that position
+  PRIMARY KEY (epoch_no, rank)
+);
+
+-- Backfill all completed epochs
+INSERT INTO bf_tbl_epoch_stake_anchor (epoch_no, rank, hash_raw)
+SELECT esp.epoch_no, t.rn - 1, t.hash_raw
+FROM epoch_stake_progress esp
+  CROSS JOIN LATERAL (
+    SELECT sa.hash_raw, row_number() OVER (ORDER BY sa.hash_raw) AS rn
+    FROM stake_address sa
+      JOIN epoch_stake es ON (es.addr_id = sa.id AND es.epoch_no = esp.epoch_no)
+  ) t
+WHERE esp.completed
+  AND NOT EXISTS (
+    SELECT 1 FROM bf_tbl_epoch_stake_anchor a WHERE a.epoch_no = esp.epoch_no
+  )
+  AND (t.rn - 1) % 1000 = 0 ON CONFLICT (epoch_no, rank) DO NOTHING;
+
+-- Maintain anchors for new epochs as db-sync completes each stake snapshot
+CREATE OR REPLACE FUNCTION bf_fn_update_bf_tbl_epoch_stake_anchor() RETURNS TRIGGER AS $$ BEGIN
+DELETE FROM bf_tbl_epoch_stake_anchor WHERE epoch_no = NEW.epoch_no;
+INSERT INTO bf_tbl_epoch_stake_anchor (epoch_no, rank, hash_raw)
+SELECT NEW.epoch_no, t.rn - 1, t.hash_raw
+FROM (
+    SELECT sa.hash_raw, row_number() OVER (ORDER BY sa.hash_raw) AS rn
+    FROM stake_address sa
+      JOIN epoch_stake es ON (es.addr_id = sa.id AND es.epoch_no = NEW.epoch_no)
+  ) t
+WHERE (t.rn - 1) % 1000 = 0;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS bf_trg_update_bf_tbl_epoch_stake_anchor ON epoch_stake_progress;
+
+CREATE TRIGGER bf_trg_update_bf_tbl_epoch_stake_anchor
+AFTER INSERT OR UPDATE ON epoch_stake_progress FOR EACH ROW
+  WHEN (NEW.completed) EXECUTE PROCEDURE bf_fn_update_bf_tbl_epoch_stake_anchor();
 ```
 
 ### Experimental features

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import fastify, { FastifyError, FastifyInstance, FastifyRequest } from 'fastify'
 import os from 'os';
 import { getConfig } from './config.js';
 import { registerRoute } from './utils/common.js';
+import { verifyEpochStakeAnchors } from './utils/database.js';
 import { errorHandler, notFoundHandler } from './utils/error-handler.js';
 import { createRequire } from 'module';
 import { registerMithrilProxy } from './proxies/mithril.js';
@@ -153,6 +154,13 @@ const start = (options = {}): FastifyInstance => {
       min: config.dbSync.minConnections,
     }),
   });
+
+  if (config.dbSync.epochStakeAnchors) {
+    // fail fast on startup when the anchor table is enabled but missing
+    app.addHook('onReady', async () => {
+      await verifyEpochStakeAnchors(app);
+    });
+  }
 
   // proxies
   registerMithrilProxy(app);

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,11 @@ export const loadConfig = () => {
     : config.has('dbSync.minConnections')
       ? config.get<number>('dbSync.minConnections')
       : undefined;
+  const databaseSyncEpochStakeAnchors = process.env.BLOCKFROST_CONFIG_DBSYNC_EPOCH_STAKE_ANCHORS
+    ? process.env.BLOCKFROST_CONFIG_DBSYNC_EPOCH_STAKE_ANCHORS === 'true'
+    : config.has('dbSync.epochStakeAnchors')
+      ? config.get<boolean>('dbSync.epochStakeAnchors')
+      : false;
   const ssl = config.has('dbSync.ssl') ? { rejectUnauthorized: false } : false;
   const databaseSyncApplicationName =
     process.env.BLOCKFROST_CONFIG_APPLICATION_NAME ??
@@ -182,6 +187,7 @@ export const loadConfig = () => {
       minConnections: databaseSyncMinConnections,
       ssl,
       applicationName: databaseSyncApplicationName,
+      epochStakeAnchors: databaseSyncEpochStakeAnchors,
     },
     network: network as Network,
     genesis,

--- a/src/routes/epochs/number/stakes/index.ts
+++ b/src/routes/epochs/number/stakes/index.ts
@@ -5,6 +5,7 @@ import { FastifyInstance, FastifyRequest } from 'fastify';
 import { SQLQuery } from '../../../../sql/index.js';
 import * as QueryTypes from '../../../../types/queries/epochs.js';
 import * as ResponseTypes from '../../../../types/responses/epochs.js';
+import { getConfig } from '../../../../config.js';
 import { getDbSync, gracefulRelease } from '../../../../utils/database.js';
 import { handle400Custom, handle404 } from '../../../../utils/error-handler.js';
 import { validatePositiveInRangeSignedInt } from '../../../../utils/validation.js';
@@ -39,11 +40,14 @@ async function route(fastify: FastifyInstance) {
               SQLQuery.get('epochs_number_stakes_unpaged'),
               [request.params.number],
             )
-          : await clientDbSync.query<QueryTypes.EpochStake>(SQLQuery.get('epochs_number_stakes'), [
-              request.params.number,
-              request.query.count,
-              request.query.page,
-            ]);
+          : await clientDbSync.query<QueryTypes.EpochStake>(
+              SQLQuery.get(
+                getConfig().dbSync.epochStakeAnchors
+                  ? 'epochs_number_stakes_anchored'
+                  : 'epochs_number_stakes',
+              ),
+              [request.params.number, request.query.count, request.query.page],
+            );
 
         gracefulRelease(clientDbSync);
 

--- a/src/sql/epochs/epochs_number_stakes.sql
+++ b/src/sql/epochs/epochs_number_stakes.sql
@@ -2,13 +2,23 @@ SELECT sa.view AS "stake_address",
   ph.view AS "pool_id",
   sorted_limited.amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow
 FROM(
-    SELECT es.id,
-      es.amount AS "amount",
+    SELECT es.amount AS "amount",
       es.addr_id,
-      es.pool_id
+      es.pool_id,
+      (
+        -- slot_no of the earliest delegation by this addr to this pool that is
+        -- effective by this epoch. Chain-derived, stable across replicas.
+        -- A long-time delegator stays at the top regardless of re-delegation churn.
+        SELECT MIN(d.slot_no)
+        FROM delegation d
+        WHERE d.addr_id = es.addr_id
+          AND d.pool_hash_id = es.pool_id
+          AND d.active_epoch_no <= es.epoch_no
+      ) AS "first_slot"
     FROM epoch_stake es
     WHERE es.epoch_no = $1
-    ORDER BY es.id ASC
+    ORDER BY first_slot ASC NULLS LAST,
+      es.addr_id ASC
     LIMIT CASE
         WHEN $2 >= 1
         AND $2 <= 100 THEN $2
@@ -27,4 +37,5 @@ FROM(
   ) AS "sorted_limited"
   JOIN pool_hash ph ON (ph.id = sorted_limited.pool_id)
   JOIN stake_address sa ON (sorted_limited.addr_id = sa.id)
-ORDER BY sorted_limited.id ASC
+ORDER BY sorted_limited.first_slot ASC NULLS LAST,
+  sorted_limited.addr_id ASC

--- a/src/sql/epochs/epochs_number_stakes.sql
+++ b/src/sql/epochs/epochs_number_stakes.sql
@@ -1,41 +1,22 @@
 SELECT sa.view AS "stake_address",
   ph.view AS "pool_id",
-  sorted_limited.amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow
-FROM(
-    SELECT es.amount AS "amount",
-      es.addr_id,
-      es.pool_id,
-      (
-        -- slot_no of the earliest delegation by this addr to this pool that is
-        -- effective by this epoch. Chain-derived, stable across replicas.
-        -- A long-time delegator stays at the top regardless of re-delegation churn.
-        SELECT MIN(d.slot_no)
-        FROM delegation d
-        WHERE d.addr_id = es.addr_id
-          AND d.pool_hash_id = es.pool_id
-          AND d.active_epoch_no <= es.epoch_no
-      ) AS "first_slot"
-    FROM epoch_stake es
-    WHERE es.epoch_no = $1
-    ORDER BY first_slot ASC NULLS LAST,
-      es.addr_id ASC
-    LIMIT CASE
+  es.amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow
+FROM stake_address sa
+  JOIN epoch_stake es ON (es.addr_id = sa.id AND es.epoch_no = $1)
+  JOIN pool_hash ph ON (ph.id = es.pool_id)
+ORDER BY sa.hash_raw ASC
+LIMIT CASE
+    WHEN $2 >= 1
+    AND $2 <= 100 THEN $2
+    ELSE 100
+  END OFFSET CASE
+    WHEN $3 > 1
+    AND $3 < 2147483647 THEN ($3 - 1) * (
+      CASE
         WHEN $2 >= 1
         AND $2 <= 100 THEN $2
         ELSE 100
-      END OFFSET CASE
-        WHEN $3 > 1
-        AND $3 < 2147483647 THEN ($3 - 1) * (
-          CASE
-            WHEN $2 >= 1
-            AND $2 <= 100 THEN $2
-            ELSE 100
-          END
-        )
-        ELSE 0
       END
-  ) AS "sorted_limited"
-  JOIN pool_hash ph ON (ph.id = sorted_limited.pool_id)
-  JOIN stake_address sa ON (sorted_limited.addr_id = sa.id)
-ORDER BY sorted_limited.first_slot ASC NULLS LAST,
-  sorted_limited.addr_id ASC
+    )
+    ELSE 0
+  END

--- a/src/sql/epochs/epochs_number_stakes_anchored.sql
+++ b/src/sql/epochs/epochs_number_stakes_anchored.sql
@@ -1,0 +1,63 @@
+-- Variant of epochs_number_stakes.sql used when bf_tbl_epoch_stake_anchor
+-- exists (maintained upstream by a db-sync trigger, see README). The anchor
+-- table stores stake_address.hash_raw at every 1000th position of the epoch's
+-- snapshot in hash_raw order; jumping to the nearest anchor at or below the
+-- requested offset makes deep pages O(1000 + count) instead of O(offset).
+-- Epochs without anchors (e.g. the one currently being synced) fall back to
+-- a plain offset scan via the COALESCE defaults.
+WITH anchor AS (
+  SELECT a.hash_raw,
+    a.rank
+  FROM bf_tbl_epoch_stake_anchor a
+  WHERE a.epoch_no = $1
+    AND a.rank <= CASE
+      WHEN $3 > 1
+      AND $3 < 2147483647 THEN ($3 - 1) * (
+        CASE
+          WHEN $2 >= 1
+          AND $2 <= 100 THEN $2
+          ELSE 100
+        END
+      )
+      ELSE 0
+    END
+  ORDER BY a.rank DESC
+  LIMIT 1
+)
+SELECT sa.view AS "stake_address",
+  ph.view AS "pool_id",
+  es.amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow
+FROM stake_address sa
+  JOIN epoch_stake es ON (es.addr_id = sa.id AND es.epoch_no = $1)
+  JOIN pool_hash ph ON (ph.id = es.pool_id)
+WHERE sa.hash_raw >= COALESCE(
+    (
+      SELECT hash_raw
+      FROM anchor
+    ),
+    '\x'::bytea
+  )
+ORDER BY sa.hash_raw ASC
+LIMIT CASE
+    WHEN $2 >= 1
+    AND $2 <= 100 THEN $2
+    ELSE 100
+  END OFFSET (
+    CASE
+      WHEN $3 > 1
+      AND $3 < 2147483647 THEN ($3 - 1) * (
+        CASE
+          WHEN $2 >= 1
+          AND $2 <= 100 THEN $2
+          ELSE 100
+        END
+      )
+      ELSE 0
+    END
+  ) - COALESCE(
+    (
+      SELECT rank
+      FROM anchor
+    ),
+    0
+  )

--- a/src/sql/epochs/epochs_number_stakes_pool_id.sql
+++ b/src/sql/epochs/epochs_number_stakes_pool_id.sql
@@ -1,6 +1,15 @@
 WITH queried_list AS (
   SELECT row_number() OVER (
-      ORDER BY es.id
+      ORDER BY (
+          -- slot_no of the earliest delegation by this addr to this pool that
+          -- is effective by this epoch. Chain-derived, stable across replicas.
+          SELECT MIN(d.slot_no)
+          FROM delegation d
+          WHERE d.addr_id = es.addr_id
+            AND d.pool_hash_id = es.pool_id
+            AND d.active_epoch_no <= es.epoch_no
+        ) ASC NULLS LAST,
+        es.addr_id ASC
     ) AS "myid",
     sa.view AS "stake_address",
     es.amount AS "amount"
@@ -9,7 +18,6 @@ WITH queried_list AS (
     JOIN pool_hash ph ON (ph.id = es.pool_id)
   WHERE es.epoch_no = $1
     AND ph.view = $4
-  ORDER BY es.id ASC
 )
 SELECT stake_address AS "stake_address",
   amount::TEXT AS "amount" -- cast to TEXT to avoid number overflow

--- a/src/sql/epochs/epochs_number_stakes_pool_id.sql
+++ b/src/sql/epochs/epochs_number_stakes_pool_id.sql
@@ -1,15 +1,6 @@
 WITH queried_list AS (
   SELECT row_number() OVER (
-      ORDER BY (
-          -- slot_no of the earliest delegation by this addr to this pool that
-          -- is effective by this epoch. Chain-derived, stable across replicas.
-          SELECT MIN(d.slot_no)
-          FROM delegation d
-          WHERE d.addr_id = es.addr_id
-            AND d.pool_hash_id = es.pool_id
-            AND d.active_epoch_no <= es.epoch_no
-        ) ASC NULLS LAST,
-        es.addr_id ASC
+      ORDER BY sa.hash_raw ASC
     ) AS "myid",
     sa.view AS "stake_address",
     es.amount AS "amount"
@@ -53,3 +44,4 @@ FROM (
         END
       )
   ) AS "staked_addresses"
+ORDER BY myid ASC

--- a/src/sql/epochs/unpaged/epochs_number_stakes.sql
+++ b/src/sql/epochs/unpaged/epochs_number_stakes.sql
@@ -5,13 +5,6 @@ FROM epoch_stake es
   JOIN pool_hash ph ON (ph.id = es.pool_id)
   JOIN stake_address sa ON (es.addr_id = sa.id)
 WHERE es.epoch_no = $1
-ORDER BY (
-    -- slot_no of the earliest delegation by this addr to this pool that is
-    -- effective by this epoch. Chain-derived, stable across replicas.
-    SELECT MIN(d.slot_no)
-    FROM delegation d
-    WHERE d.addr_id = es.addr_id
-      AND d.pool_hash_id = es.pool_id
-      AND d.active_epoch_no <= es.epoch_no
-  ) ASC NULLS LAST,
-  es.addr_id ASC
+-- hash_raw is chain-derived, so the ordering is stable across replicas
+-- (and matches the paged variant of this query)
+ORDER BY sa.hash_raw ASC

--- a/src/sql/epochs/unpaged/epochs_number_stakes.sql
+++ b/src/sql/epochs/unpaged/epochs_number_stakes.sql
@@ -5,4 +5,13 @@ FROM epoch_stake es
   JOIN pool_hash ph ON (ph.id = es.pool_id)
   JOIN stake_address sa ON (es.addr_id = sa.id)
 WHERE es.epoch_no = $1
-ORDER BY es.id ASC
+ORDER BY (
+    -- slot_no of the earliest delegation by this addr to this pool that is
+    -- effective by this epoch. Chain-derived, stable across replicas.
+    SELECT MIN(d.slot_no)
+    FROM delegation d
+    WHERE d.addr_id = es.addr_id
+      AND d.pool_hash_id = es.pool_id
+      AND d.active_epoch_no <= es.epoch_no
+  ) ASC NULLS LAST,
+  es.addr_id ASC

--- a/src/sql/epochs/unpaged/epochs_number_stakes_pool_id.sql
+++ b/src/sql/epochs/unpaged/epochs_number_stakes_pool_id.sql
@@ -5,4 +5,13 @@ FROM epoch_stake es
   JOIN pool_hash ph ON (ph.id = es.pool_id)
 WHERE es.epoch_no = $1
   AND ph.view = $2
-ORDER BY es.id ASC
+ORDER BY (
+    -- slot_no of the earliest delegation by this addr to this pool that is
+    -- effective by this epoch. Chain-derived, stable across replicas.
+    SELECT MIN(d.slot_no)
+    FROM delegation d
+    WHERE d.addr_id = es.addr_id
+      AND d.pool_hash_id = es.pool_id
+      AND d.active_epoch_no <= es.epoch_no
+  ) ASC NULLS LAST,
+  es.addr_id ASC

--- a/src/sql/epochs/unpaged/epochs_number_stakes_pool_id.sql
+++ b/src/sql/epochs/unpaged/epochs_number_stakes_pool_id.sql
@@ -5,13 +5,6 @@ FROM epoch_stake es
   JOIN pool_hash ph ON (ph.id = es.pool_id)
 WHERE es.epoch_no = $1
   AND ph.view = $2
-ORDER BY (
-    -- slot_no of the earliest delegation by this addr to this pool that is
-    -- effective by this epoch. Chain-derived, stable across replicas.
-    SELECT MIN(d.slot_no)
-    FROM delegation d
-    WHERE d.addr_id = es.addr_id
-      AND d.pool_hash_id = es.pool_id
-      AND d.active_epoch_no <= es.epoch_no
-  ) ASC NULLS LAST,
-  es.addr_id ASC
+-- hash_raw is chain-derived, so the ordering is stable across replicas
+-- (and matches the paged variant of this query)
+ORDER BY sa.hash_raw ASC

--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -88,6 +88,7 @@ const QUERY_FILES = {
   epochs_number_previous: 'epochs/epochs_number_previous.sql',
   epochs_number_previous_unpaged: 'epochs/unpaged/epochs_number_previous.sql',
   epochs_number_stakes: 'epochs/epochs_number_stakes.sql',
+  epochs_number_stakes_anchored: 'epochs/epochs_number_stakes_anchored.sql',
   epochs_number_stakes_unpaged: 'epochs/unpaged/epochs_number_stakes.sql',
   epochs_number_stakes_pool_id: 'epochs/epochs_number_stakes_pool_id.sql',
   epochs_number_stakes_pool_id_unpaged: 'epochs/unpaged/epochs_number_stakes_pool_id.sql',

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -20,3 +20,24 @@ export const gracefulRelease = (clientDbSync: PoolClient) => {
     console.warn(error);
   }
 };
+
+// Verifies that the bf_tbl_epoch_stake_anchor table (see README) exists when
+// dbSync.epochStakeAnchors is enabled. Called once during server startup.
+export const verifyEpochStakeAnchors = async (fastify: FastifyInstance): Promise<void> => {
+  const clientDbSync = await getDbSync(fastify);
+
+  try {
+    const result = await clientDbSync.query<{ exists: boolean }>(
+      "SELECT to_regclass('public.bf_tbl_epoch_stake_anchor') IS NOT NULL AS exists",
+    );
+
+    if (!result.rows[0].exists) {
+      throw new Error(
+        'dbSync.epochStakeAnchors is enabled, but table bf_tbl_epoch_stake_anchor is missing in the db-sync database. ' +
+          'Create the table and its trigger (see README, "Epoch stake pagination anchors") or disable the option.',
+      );
+    }
+  } finally {
+    gracefulRelease(clientDbSync);
+  }
+};


### PR DESCRIPTION
# Stable ordering for `/epochs/:number/stakes` across db-sync replicas

## Problem

Two API instances backed by independently-synced db-sync databases (bit-identical chain data) returned a **different first page** for the same `/epochs/:number/stakes` request. The queries ordered by `epoch_stake.id` — an auto-increment assigned at row-insertion time. db-sync recomputes the per-epoch stake snapshot, and rollback/replay causes different `id` assignment across instances. The data is identical; only the pagination key diverged.

## Fix

Order all four query variants (paged/unpaged × all/per-pool) by **`stake_address.hash_raw`** — the raw 29-byte stake credential (`0xe1` header + blake2b-224 hash). It's actual on-chain data, so every db-sync instance stores identical bytes: the ordering is replica-stable by construction, total (verified: `(epoch_no, addr_id)` is unique across all 456M mainnet `epoch_stake` rows, so there are no ties), and identical between the paged and unpaged variants.

Row ordering is not a guaranteed part of the API contract; request/response shape, status codes and the per-epoch row set are unchanged.

> An earlier iteration on this branch ordered by earliest delegation `slot_no`. That was abandoned for two reasons: the sort key had to be computed for all ~1.3M rows of the epoch on every request (~5s for page 1), and its `es.addr_id` tie-break is replica-local — i.e. not actually stable (up to 98 delegation certs share a single slot on mainnet, so the tie-break fires constantly).

## Deep-page cost & the optional anchor table

Because the sort key lives on `stake_address` (not `epoch_stake`), `LIMIT/OFFSET` can no longer ride a single-table index walk: deep pages degrade to O(offset) index probes (~4.45× overscan — 5.87M total stake addresses vs ~1.32M active per epoch).

| page (count=100), epoch 500 | master (`es.id`) | `hash_raw` plain | `hash_raw` + anchors |
|---|---|---|---|
| 1 | 17 ms | ~140 ms | ~5–40 ms |
| 100 | tens–hundreds ms | 1.2–10 s | ~25 ms |
| 1,000 | — | ~3.5 s | **44 ms** |
| 12,010 (offset 1.2M) | ~0.5–2 s | minutes | **~60 ms** |

The accelerator is a small table, `bf_tbl_epoch_stake_anchor` (~60 MB for the full mainnet history), storing `hash_raw` at every 1000th position of each epoch's snapshot in `hash_raw` order. The anchored query jumps to the nearest anchor at or below the requested offset and keyset-scans from there — O(1000 + count) for any page. Epoch snapshots are immutable once written, so anchors are built once per epoch (~2.3 s) by a trigger on `epoch_stake_progress` (fires when db-sync marks the snapshot complete; delete+rebuild per firing, so rollback/replay self-heals). Table + trigger DDL is in the README.

The anchored query was validated row-identical to the plain query on page 1, a misaligned `count=37` page, page 1000 and past-the-end (empty) pages.

### Configuration

```yaml
dbSync:
  epochStakeAnchors: true # ENV: BLOCKFROST_CONFIG_DBSYNC_EPOCH_STAKE_ANCHORS
```

- **Default off** — vanilla db-sync deployments are unaffected and get the same (stable) ordering, just slower deep pages. The flag changes performance only, never ordering.
- **Fail-fast** — if the flag is enabled but the table is missing, the server refuses to start with a descriptive error.

## Related

- `/epochs/:number/stakes/:pool_id` has an independent bottleneck (BitmapAnd over all epochs of a pool, ~12M rows / ~1.3 s for the largest pools): fixed by the new recommended index `bf_idx_epoch_stake_pool_id_epoch_no` (see README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
