### PR TITLE
perf(docker): layered Nix image + slim the fallback Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+dist
+result
+coverage
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nixos/nix
 COPY . /app
 WORKDIR /app
-RUN nix-build -A blockfrost-backend-ryo
-RUN ln -s $(nix-build -A blockfrost-backend-ryo --no-out-link)/bin/blockfrost-backend-ryo /app/blockfrost-backend-ryo
-ENTRYPOINT ["/app/blockfrost-backend-ryo"]
+# Build once; `-o result` leaves a symlink to the store output we run from.
+RUN nix-build -A blockfrost-backend-ryo -o result
+ENTRYPOINT ["/app/result/bin/blockfrost-backend-ryo"]
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nixos/nix
 COPY . /app
 WORKDIR /app
-# Build once; `-o result` leaves a symlink to the store output we run from.
-RUN nix-build -A blockfrost-backend-ryo -o result
+# Build once via the flake; `-o result` leaves a symlink to the store output we run from.
+RUN nix --extra-experimental-features 'nix-command flakes' build .#blockfrost-backend-ryo -o result
 ENTRYPOINT ["/app/result/bin/blockfrost-backend-ryo"]
 EXPOSE 3000

--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,13 @@
                 cp -a ${self.packages.${system}.blockfrost-backend-ryo}/libexec/source/config $out/app/config
               '';
           in
-          legacyPkgs.${system}.dockerTools.buildImage {
+          legacyPkgs.${system}.dockerTools.buildLayeredImage {
             name = "backend-ryo";
             copyToRoot = [ configs ];
             config = {
               Cmd = [ "${self.packages.${system}.blockfrost-backend-ryo}/bin/blockfrost-backend-ryo" ];
               WorkingDir = "/app";
+              ExposedPorts = { "3000/tcp" = { }; };
             };
           };
         default = self.packages.${system}.blockfrost-backend-ryo-wrapper;


### PR DESCRIPTION
Two independent Docker build paths optimized. Independent of the 6.6.1 security release (already merged & published).

## 1. Published image — `buildImage` → `buildLayeredImage` ([flake.nix](flake.nix))

This is the image CI actually publishes. Verified on `v6.6.1` it's a **single ~382 MiB layer**:

```
"layers": [ { "size": 400664085, ... } ]   # one layer
```

`buildImage` packs the whole runtime closure into that one layer, so every release re-pushes and re-pulls the entire image. `buildLayeredImage` instead splits the closure into multiple content-addressed layers — **automatically, at `nix build` time, derived from the Nix store closure** (no Docker `COPY`/`RUN` layering and nothing to add in the workflow; `docker load`/`push` then dedup per layer).

**What this does and does not buy us here** (the layering can only split along store-path boundaries):
- ✅ The stable toolchain store paths — `nodejs_24`, `pm2`, `pm2-prom-module`, `glibc`, `bash`, openssl, … — each become their own cached layer, **shared across releases**. These are a large fraction of the image and no longer re-transfer on an app/dep change.
- ⚠️ The app itself is a **single store path** containing source + `node_modules` + `dist` (see [yarn-project.nix:101-108](yarn-project.nix#L101-L108) — `installPhase` does `mv $PWD $out`). So those share **one layer**: a dependency bump like 6.6.1 re-pushes that whole combined layer, **not** just the changed packages.

So this is a strict improvement over the monolithic single layer (toolchain becomes shared/cached), but it does **not** give true "deps layer vs app layer" separation — that would require emitting `node_modules` as its own derivation/store path (possible follow-up, out of scope here). **Image contents are identical** either way.

Also declared `ExposedPorts = { "3000/tcp" = {}; }` — the Nix image previously carried no port metadata (only the Dockerfile did).

All consumers (`nix build .#dockerImage`, `nix flake check`) are unchanged; `name`/`copyToRoot`/`config` are accepted identically. The release workflow finds the image by `--filter reference=backend-ryo` (not by tag), so the unchanged `name` keeps that step working.

## 2. Fallback Dockerfile — slimmed ([Dockerfile](Dockerfile), [.dockerignore](.dockerignore))

The Dockerfile (manual/fallback build, **not** what CI publishes) ran `nix-build` **twice** — once for the `result` symlink, then again with `--no-out-link` only to resolve a path for a second symlink. Now builds **once** and runs from `result/bin/...`. Per review, switched to the flake CLI (`nix build .#blockfrost-backend-ryo`) so it no longer depends on `default.nix`; experimental features are enabled inline because the `nixos/nix` base image (upstream CppNix) does not enable `nix-command`/`flakes` by default — they remain officially experimental upstream.

Added a **`.dockerignore`** so `COPY . /app` stops pulling `.git`, `node_modules`, `dist`, `result` and coverage into the image layer.

Left as-is intentionally: full multi-stage slimming of the Dockerfile — over-engineering for a fallback path when the published artifact is the Nix image above.

## ⚠️ Validation note

**No PR-level CI builds `dockerImage`** — CI.yaml runs only node lint/test/build; the Nix image is built solely by the release workflow (`Docker.yaml`, on `release: published`). I could not build locally (no Nix on this machine). Please validate before merge / before the next release:

```console
# Published Nix image
nix build .#dockerImage
docker load < result
docker history <image>     # expect multiple layers, not one

# Fallback Dockerfile
docker build -t backend-ryo-dockerfile .
docker run --rm -p 3000:3000 -e BLOCKFROST_CONFIG_SERVER_LISTEN_ADDRESS=0.0.0.0 -v $PWD/config:/app/config backend-ryo-dockerfile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)