### PR TITLE
feat(sql): optimize address total asset aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ CREATE INDEX IF NOT EXISTS bf_idx_redeemer_tx_id ON redeemer USING btree (tx_id)
 CREATE INDEX IF NOT EXISTS bf_idx_col_tx_out ON collateral_tx_out USING btree (tx_id);
 CREATE INDEX IF NOT EXISTS bf_idx_ma_tx_mint_ident ON ma_tx_mint USING btree (ident);
 CREATE INDEX IF NOT EXISTS bf_idx_ma_tx_out_ident ON ma_tx_out USING btree (ident);
+CREATE INDEX IF NOT EXISTS bf_idx_ma_tx_out_tx_out_id_covering ON ma_tx_out (tx_out_id) INCLUDE (ident, quantity);
 CREATE INDEX IF NOT EXISTS bf_idx_reward_rest_addr_id ON reward_rest USING btree (addr_id);
 CREATE INDEX IF NOT EXISTS bf_idx_reward_rest_spendable_epoch ON reward_rest USING btree (spendable_epoch);
 CREATE INDEX IF NOT EXISTS bf_idx_drep_hash_raw ON drep_hash USING hash (raw);
@@ -296,4 +297,3 @@ This just mean you have to give the db user blockfrost uses to connect permissio
 ```sql
 GRANT USAGE ON SCHEMA cardano TO username;
 ```
-

--- a/src/sql/accounts/accounts_stake_address_addresses_total.sql
+++ b/src/sql/accounts/accounts_stake_address_addresses_total.sql
@@ -1,40 +1,36 @@
-WITH queried_outputs AS (
-  SELECT COALESCE(txo.value, 0) AS "amount",
-    array_agg(mto.id) AS "assets_ids",
-    array_agg(DISTINCT tx.id) AS "txids"
-  FROM tx
-    JOIN tx_in txi ON (txi.tx_in_id = tx.id)
-    JOIN tx_out txo ON (
-      txo.tx_id = txi.tx_out_id
-      AND txo.index = txi.tx_out_index
-    )
-    JOIN stake_address sa ON (txo.stake_address_id = sa.id)
-    LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
-  WHERE sa.view = $1
-  GROUP BY txo.id
+WITH matched_stake_address AS MATERIALIZED (
+  SELECT id,
+    view
+  FROM stake_address
+  WHERE view = $1
+  LIMIT 1
 ),
-queried_inputs AS (
-  SELECT COALESCE(txo.value, 0) AS "amount",
-    array_agg(mto.id) AS "assets_ids",
-    array_agg(DISTINCT tx.id) AS "txids"
-  FROM tx
-    JOIN tx_out txo ON (txo.tx_id = tx.id)
-    JOIN stake_address sa ON (txo.stake_address_id = sa.id)
-    LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
-  WHERE sa.view = $1
-  GROUP BY txo.id
+matched_received AS MATERIALIZED (
+  SELECT txo.id AS "tx_out_id",
+    COALESCE(txo.value, 0) AS "value",
+    txo.tx_id AS "txid"
+  FROM tx_out txo
+    JOIN matched_stake_address sa ON (txo.stake_address_id = sa.id)
+),
+matched_sent AS MATERIALIZED (
+  SELECT txo.id AS "tx_out_id",
+    COALESCE(txo.value, 0) AS "value",
+    txi.tx_in_id AS "txid"
+  FROM tx_out txo
+    JOIN matched_stake_address sa ON (txo.stake_address_id = sa.id)
+    JOIN tx_in txi ON (
+      txi.tx_out_id = txo.tx_id
+      AND txi.tx_out_index = txo.index
+    )
 )
 SELECT (
-    SELECT sa.view
-    FROM tx_out txo
-      JOIN stake_address sa ON (txo.stake_address_id = sa.id)
-    WHERE sa.view = $1
-    LIMIT 1
+    SELECT view
+    FROM matched_stake_address
   ) AS "stake_address",
   (
     (
-      SELECT COALESCE(SUM(amount), 0)::TEXT -- cast to TEXT to avoid number overflow
-      FROM queried_outputs
+      SELECT COALESCE(SUM(value), 0)::TEXT -- cast to TEXT to avoid number overflow
+      FROM matched_sent
     )
   ) AS "sent_amount_lovelace",
   (
@@ -48,22 +44,20 @@ SELECT (
       )
     FROM (
         SELECT CONCAT(encode(ma.policy, 'hex'), encode(ma.name, 'hex')) AS "token_name",
-          SUM(quantity) AS "token_quantity"
-        FROM ma_tx_out mto
+          SUM(mto.quantity) AS "token_quantity"
+        FROM matched_sent ms
+          JOIN ma_tx_out mto ON (mto.tx_out_id = ms.tx_out_id)
           JOIN multi_asset ma ON (mto.ident = ma.id)
-        WHERE mto.id IN (
-            SELECT unnest(assets_ids)
-            FROM queried_outputs
-          )
         GROUP BY ma.name,
           ma.policy
-        ORDER BY (ma.policy, ma.name)
+        ORDER BY ma.policy,
+          ma.name
       ) AS "assets"
   ) AS "sent_amount",
   (
     (
-      SELECT COALESCE(SUM(amount), 0)::TEXT -- cast to TEXT to avoid number overflow
-      FROM queried_inputs
+      SELECT COALESCE(SUM(value), 0)::TEXT -- cast to TEXT to avoid number overflow
+      FROM matched_received
     )
   ) AS "received_amount_lovelace",
   (
@@ -77,29 +71,23 @@ SELECT (
       )
     FROM (
         SELECT CONCAT(encode(ma.policy, 'hex'), encode(ma.name, 'hex')) AS "token_name",
-          SUM(quantity) AS "token_quantity"
-        FROM ma_tx_out mto
+          SUM(mto.quantity) AS "token_quantity"
+        FROM matched_received mr
+          JOIN ma_tx_out mto ON (mto.tx_out_id = mr.tx_out_id)
           JOIN multi_asset ma ON (mto.ident = ma.id)
-        WHERE mto.id IN (
-            SELECT unnest(assets_ids)
-            FROM queried_inputs
-          )
         GROUP BY ma.name,
           ma.policy
-        ORDER BY (ma.policy, ma.name)
+        ORDER BY ma.policy,
+          ma.name
       ) AS "assets"
   ) AS "received_amount",
   (
-    SELECT COUNT(*)
+    SELECT COUNT(DISTINCT txid)
     FROM (
-        (
-          SELECT txids
-          FROM queried_inputs
-        )
-        UNION
-        (
-          SELECT txids
-          FROM queried_outputs
-        )
-      ) AS "unique_txs"
+        SELECT txid
+        FROM matched_received
+        UNION ALL
+        SELECT txid
+        FROM matched_sent
+      ) AS "txs"
   ) AS "tx_count"

--- a/src/sql/addresses/addresses_address_total.sql
+++ b/src/sql/addresses/addresses_address_total.sql
@@ -1,36 +1,26 @@
-WITH queried_outputs AS (
-  SELECT COALESCE(txo.value, 0) AS "amount",
-    array_agg(mto.id) AS "assets_ids",
-    array_agg(DISTINCT tx.id) AS "txids"
-  FROM tx
-    JOIN tx_in txi ON (txi.tx_in_id = tx.id)
-    JOIN tx_out txo ON (
-      txo.tx_id = txi.tx_out_id
-      AND txo.index = txi.tx_out_index
-    )
-    LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
+WITH matched_received AS MATERIALIZED (
+  SELECT txo.id AS "tx_out_id",
+    COALESCE(txo.value, 0) AS "value",
+    txo.tx_id AS "txid"
+  FROM tx_out txo
   WHERE (
-      CASE
-        WHEN $2::BYTEA IS NOT NULL THEN txo.payment_cred = $2
-        ELSE txo.address = $1
-      END
+      ($2::BYTEA IS NOT NULL AND txo.payment_cred = $2)
+      OR ($2::BYTEA IS NULL AND txo.address = $1)
     )
-  GROUP BY txo.id
 ),
-queried_inputs AS (
-  SELECT COALESCE(txo.value, 0) AS "amount",
-    array_agg(mto.id) AS "assets_ids",
-    array_agg(DISTINCT tx.id) AS "txids"
-  FROM tx
-    JOIN tx_out txo ON (txo.tx_id = tx.id)
-    LEFT JOIN ma_tx_out mto ON (mto.tx_out_id = txo.id)
-  WHERE (
-      CASE
-        WHEN $2::BYTEA IS NOT NULL THEN txo.payment_cred = $2
-        ELSE txo.address = $1
-      END
+matched_sent AS MATERIALIZED (
+  SELECT txo.id AS "tx_out_id",
+    COALESCE(txo.value, 0) AS "value",
+    txi.tx_in_id AS "txid"
+  FROM tx_out txo
+    JOIN tx_in txi ON (
+      txi.tx_out_id = txo.tx_id
+      AND txi.tx_out_index = txo.index
     )
-  GROUP BY txo.id
+  WHERE (
+      ($2::BYTEA IS NOT NULL AND txo.payment_cred = $2)
+      OR ($2::BYTEA IS NULL AND txo.address = $1)
+    )
 )
 SELECT (
     SELECT CASE
@@ -45,8 +35,8 @@ SELECT (
   ) AS "address",
   (
     (
-      SELECT COALESCE(SUM(amount), 0)::TEXT -- cast to TEXT to avoid number overflow
-      FROM queried_outputs
+      SELECT COALESCE(SUM(value), 0)::TEXT -- cast to TEXT to avoid number overflow
+      FROM matched_sent
     )
   ) AS "sent_amount_lovelace",
   (
@@ -60,22 +50,20 @@ SELECT (
       )
     FROM (
         SELECT CONCAT(encode(ma.policy, 'hex'), encode(ma.name, 'hex')) AS "token_name",
-          SUM(quantity) AS "token_quantity"
-        FROM ma_tx_out mto
+          SUM(mto.quantity) AS "token_quantity"
+        FROM matched_sent ms
+          JOIN ma_tx_out mto ON (mto.tx_out_id = ms.tx_out_id)
           JOIN multi_asset ma ON (mto.ident = ma.id)
-        WHERE mto.id IN (
-            SELECT unnest(assets_ids)
-            FROM queried_outputs
-          )
         GROUP BY ma.name,
           ma.policy
-        ORDER BY (ma.policy, ma.name)
+        ORDER BY ma.policy,
+          ma.name
       ) AS "assets"
   ) AS "sent_amount",
   (
     (
-      SELECT COALESCE(SUM(amount), 0)::TEXT -- cast to TEXT to avoid number overflow
-      FROM queried_inputs
+      SELECT COALESCE(SUM(value), 0)::TEXT -- cast to TEXT to avoid number overflow
+      FROM matched_received
     )
   ) AS "received_amount_lovelace",
   (
@@ -89,29 +77,23 @@ SELECT (
       )
     FROM (
         SELECT CONCAT(encode(ma.policy, 'hex'), encode(ma.name, 'hex')) AS "token_name",
-          SUM(quantity) AS "token_quantity"
-        FROM ma_tx_out mto
+          SUM(mto.quantity) AS "token_quantity"
+        FROM matched_received mr
+          JOIN ma_tx_out mto ON (mto.tx_out_id = mr.tx_out_id)
           JOIN multi_asset ma ON (mto.ident = ma.id)
-        WHERE mto.id IN (
-            SELECT unnest(assets_ids)
-            FROM queried_inputs
-          )
         GROUP BY ma.name,
           ma.policy
-        ORDER BY (ma.policy, ma.name)
+        ORDER BY ma.policy,
+          ma.name
       ) AS "assets"
   ) AS "received_amount",
   (
-    SELECT COUNT(*)
+    SELECT COUNT(DISTINCT txid)
     FROM (
-        (
-          SELECT txids
-          FROM queried_inputs
-        )
-        UNION
-        (
-          SELECT txids
-          FROM queried_outputs
-        )
-      ) AS "unique_txs"
+        SELECT txid
+        FROM matched_received
+        UNION ALL
+        SELECT txid
+        FROM matched_sent
+      ) AS "txs"
   ) AS "tx_count"


### PR DESCRIPTION
Optimized the address total queries so they no longer collect `ma_tx_out.id` values into arrays and then query `ma_tx_out` again.

The new query flow collects matching received and sent `tx_out` rows first, joins assets directly through `ma_tx_out.tx_out_id`, removes redundant joins to `tx`, counts distinct transaction IDs directly, and documents a covering index for `ma_tx_out(tx_out_id)`.

The old query was doing a lot of extra work for large addresses: touching `ma_tx_out` to collect asset IDs, unnesting large ID arrays, and then looking up those same asset rows again by primary key. For addresses with millions of outputs, that path is very expensive. The new shape keeps the asset work tied to the matched outputs and avoids the second lookup path.

One behavior change: `tx_count` now counts distinct scalar transaction IDs. The previous query counted distinct arrays of transaction IDs, which was fragile and not the intended API meaning.