### PR TITLE
fix(accounts): resolve same-tx certificate ordering by (tx_id, cert_index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `@blockfrost/openapi` to 0.1.91, which declares the `from`/`to` parameters of `/assets/:asset/transactions`
 
+### Fixed
+
+- `/accounts/:stake_address` no longer reports `registered: false` (and `active: false` with a null `pool_id`) for accounts whose latest deregistration and re-registration happened in the same transaction. Certificate comparisons now use `(tx_id, cert_index)` in ledger order instead of bare `tx_id` (#349)
+
 ## [6.7.1] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [6.7.2] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.7.2] - 2026-08-05
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockfrost-backend-ryo",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "",
   "keywords": [],
   "license": "Apache-2.0",

--- a/src/sql/accounts/accounts_stake_address.sql
+++ b/src/sql/accounts/accounts_stake_address.sql
@@ -20,24 +20,32 @@ queried_pool AS (
       FROM delegation
       WHERE addr_id = sa.id
     )
-    AND sr.tx_id = (
-      SELECT MAX(tx_id)
+    -- certificates within one tx apply in cert_index order, so ties on tx_id
+    -- are broken by cert_index (e.g. dereg + re-reg in the same tx)
+    AND (sr.tx_id, sr.cert_index) = (
+      SELECT tx_id, cert_index
       FROM stake_registration
       WHERE addr_id = sa.id
+      ORDER BY tx_id DESC, cert_index DESC
+      LIMIT 1
     )
     AND (
-      sr.tx_id > (
-        SELECT COALESCE(MAX(tx_id), 0) -- handles IS NULL option so we don't have to run that query again
+      ROW(sr.tx_id, sr.cert_index) > COALESCE((
+        SELECT ROW(tx_id, cert_index)
         FROM stake_deregistration
         WHERE addr_id = sa.id
-      )
+        ORDER BY tx_id DESC, cert_index DESC
+        LIMIT 1
+      ), ROW(-1::bigint, -1::integer))
     )
     AND (
-      d.tx_id > (
-        SELECT COALESCE(MAX(tx_id), 0) -- delegation must be after latest deregistration
+      ROW(d.tx_id, d.cert_index) > COALESCE(( -- delegation must be after latest deregistration
+        SELECT ROW(tx_id, cert_index)
         FROM stake_deregistration
         WHERE addr_id = sa.id
-      )
+        ORDER BY tx_id DESC, cert_index DESC
+        LIMIT 1
+      ), ROW(-1::bigint, -1::integer))
     )
 ),
 queried_drep AS (
@@ -116,12 +124,18 @@ SELECT sa.view AS "stake_address",
       )
   ) AS "active_epoch",
   (
+    -- compare (tx_id, cert_index) so a dereg + re-reg within the same tx
+    -- resolves in ledger (cert_index) order
     COALESCE(
-      (SELECT MAX(tx_id) FROM stake_registration WHERE addr_id = (SELECT * FROM queried_addr)),
-      0
+      (SELECT ROW(tx_id, cert_index) FROM stake_registration
+        WHERE addr_id = (SELECT * FROM queried_addr)
+        ORDER BY tx_id DESC, cert_index DESC LIMIT 1),
+      ROW(-1::bigint, -1::integer)
     ) > COALESCE(
-      (SELECT MAX(tx_id) FROM stake_deregistration WHERE addr_id = (SELECT * FROM queried_addr)),
-      0
+      (SELECT ROW(tx_id, cert_index) FROM stake_deregistration
+        WHERE addr_id = (SELECT * FROM queried_addr)
+        ORDER BY tx_id DESC, cert_index DESC LIMIT 1),
+      ROW(-1::bigint, -1::integer)
     )
   ) AS "registered",
   (


### PR DESCRIPTION
Fixes #349

## Problem

`/accounts/:stake_address` decided `registered` by comparing `MAX(stake_registration.tx_id) > MAX(stake_deregistration.tx_id)`. When the latest deregistration and re-registration happen in the **same transaction** (dereg at cert_index 0, re-reg at cert_index 1), both MAXes are equal and the strict `>` yields `false` — the account is wrongly reported as unregistered. The `queried_pool` CTE had the same flaw in three comparisons, additionally producing `active: false` and `pool_id: null` when a delegation shares the tx.

Verified against the issue's preprod account (Koios: `registered`; Blockfrost: `registered: false`) — and it's not just preprod: **~120 mainnet accounts** currently have a same-tx dereg+reg pair, nearly all misreported.

## Fix

Compare `(tx_id, cert_index)` tuples in ledger order, mirroring the ROW-comparison idiom already used by the drep checks in the same file.

## Validation (mainnet dev dbsync)

- For all affected mainnet accounts, old vs new `registered` flips `false → true` except where a genuinely-final deregistration exists; spot-checked both directions against Koios `account_info` (`stake1uyt68v8…`: Koios *registered*, new logic ✓; `stake1uxje0uvm…`: Koios *not registered*, new logic ✓).
- The flipped account also recovers its delegation: new query returns `pool1frz0ds…`, matching Koios `delegated_pool` exactly.
- Old/new can only disagree when the latest reg and dereg share a `tx_id`, so behavior for all other accounts is unchanged by construction.

## Performance

No measurable impact (warm, mainnet dev dbsync, full query): worst-case account with 218 registration certs — 26.5 ms old vs 26.6 ms new; typical accounts ~8.7 ms both. The `ORDER BY tx_id DESC, cert_index DESC LIMIT 1` top-1 over an account's handful of cert rows costs the same as `MAX(tx_id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)